### PR TITLE
Add NPS (National Park Service) parks and alerts tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,18 @@ API Availability:
 
 ---
 
+### CISA (Cybersecurity)
+
+| Tool | What It Does | Parameters |
+|------|--------------|------------|
+| `get_kev_vulnerabilities` | CISA Known Exploited Vulnerabilities (KEV) catalog | `cve_id` - filter by specific CVE, `limit` - max results (default: 20) |
+| `get_cisa_alerts` | Get CISA security alerts and advisories | `limit` - max results (default: 10), `keyword` - filter by keyword |
+| `get_security_advisories` | Get CISA security advisories by vendor/product | `vendor` - filter by vendor, `product` - filter by product, `limit` - max results |
+| `search_kev_by_ransomware` | Get vulnerabilities used in ransomware campaigns | `limit` - max results (default: 20) |
+| `get_critical_kev` | Get recently added critical vulnerabilities | `days` - lookback period (default: 30), `limit` - max results |
+
+---
+
 ## Development
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ python -m mcp_govt_api
 | [EU Open Data](https://data.europa.eu) | European Union datasets, multilingual | -- |
 | [NASA](https://api.nasa.gov) | APOD, Mars rover photos, image/video library | Optional |
 
+### Parks & Recreation
+
+| Source | What It Covers | Key |
+|--------|---------------|-----|
+| [NPS](https://www.nps.gov/subjects/developer) | National Parks, alerts, campgrounds, events | Required |
+
 > **Key**: `--` = no key needed. `Optional` = works without a key, key unlocks higher rate limits. `Required` = key needed to enable.
 
 ---
@@ -101,6 +107,9 @@ python -m mcp_govt_api
 "What are the radiation levels near Fukushima?"
 "What are stream flow levels in Colorado?"
 "Find datasets about climate change on Data.gov"
+"What national parks are in California?"
+"Tell me about Yellowstone National Park"
+"Are there any alerts for Grand Canyon?"
 ```
 
 ---
@@ -225,6 +234,18 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 </details>
 
 <details>
+<summary><strong>National Park Service</strong> — 4 tools</summary>
+
+| Tool | Description |
+|------|-------------|
+| `search_parks` | Search parks by state, name, or keywords |
+| `get_park_details` | Get detailed park info including activities, fees, hours |
+| `get_park_alerts` | Get park alerts, closures, and warnings |
+| `query_nps` | Raw NPS API access |
+
+</details>
+
+<details>
 <summary><strong>Open Data</strong> — 6 tools</summary>
 
 | Tool | Description |
@@ -246,6 +267,7 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 |----------|---------|---------|
 | `OPENWEATHER_API_KEY` | Enables global weather tools | *(disabled)* |
 | `NASA_API_KEY` | Higher rate limits for NASA + FIRMS | `DEMO_KEY` (30 req/hr) |
+| `NPS_API_KEY` | Enables National Park Service tools | *(disabled)* |
 | `API_TIMEOUT` | Request timeout in seconds | `30` |
 
 On startup the server prints which APIs are available:
@@ -270,6 +292,24 @@ API Availability:
 | `get_security_advisories` | Get CISA security advisories by vendor/product | `vendor` - filter by vendor, `product` - filter by product, `limit` - max results |
 | `search_kev_by_ransomware` | Get vulnerabilities used in ransomware campaigns | `limit` - max results (default: 20) |
 | `get_critical_kev` | Get recently added critical vulnerabilities | `days` - lookback period (default: 30), `limit` - max results |
+
+### NREL (Clean Energy)
+
+| Tool | What It Does | Parameters |
+|------|--------------|------------|
+| `get_nearby_ev_chargers` | Find EV charging stations near a location | `latitude` - Latitude coordinate, `longitude` - Longitude coordinate, `radius_miles` - Search radius (default: 10), `limit` - Max results (default: 10) |
+| `get_alternative_fuel_stations` | Find alternative fuel stations (EV, hydrogen, CNG, etc.) | `latitude`/`longitude` OR `city`/`state` OR `zip_code` - Location, `fuel_type` - Filter by type (ELEC, HY, CNG, LNG, LPG, BD, E85, RD), `radius_miles` - Search radius, `limit` - Max results |
+| `get_clean_energy_site_summary` | Get summary of clean energy infrastructure near a location | `latitude` - Latitude coordinate, `longitude` - Longitude coordinate, `radius_miles` - Search radius (default: 25) |
+
+**Fuel Types:**
+- `ELEC` - Electric
+- `HY` - Hydrogen
+- `CNG` - Compressed Natural Gas
+- `LNG` - Liquefied Natural Gas
+- `LPG` - Propane
+- `BD` - Biodiesel
+- `E85` - Ethanol
+- `RD` - Renewable Diesel
 
 ---
 

--- a/src/mcp_govt_api/server.py
+++ b/src/mcp_govt_api/server.py
@@ -18,6 +18,7 @@ mcp = FastMCP(
 - USGS Earthquakes (global seismic data)
 - NASA FIRMS (active wildfire detection)
 - NOAA Space Weather (solar wind, flares, geomagnetic storms)
+- CISA (cybersecurity advisories, known exploited vulnerabilities, alerts)
 """,
 )
 
@@ -41,3 +42,4 @@ from mcp_govt_api.tools import usgs_water  # noqa: E402, F401
 from mcp_govt_api.tools import earthquakes  # noqa: E402, F401
 from mcp_govt_api.tools import firms  # noqa: E402, F401
 from mcp_govt_api.tools import space_weather  # noqa: E402, F401
+from mcp_govt_api.tools import cisa  # noqa: E402, F401

--- a/src/mcp_govt_api/tools/__init__.py
+++ b/src/mcp_govt_api/tools/__init__.py
@@ -1,1 +1,2 @@
 # Tools are registered via decorators when imported
+from mcp_govt_api.tools import nps

--- a/src/mcp_govt_api/tools/cisa.py
+++ b/src/mcp_govt_api/tools/cisa.py
@@ -1,0 +1,361 @@
+"""CISA cybersecurity tools - Known Exploited Vulnerabilities and Alerts."""
+
+from mcp_govt_api.server import mcp
+from mcp_govt_api.utils.http import fetch_json
+
+
+CISA_KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+CISA_ALERTS_URL = "https://www.cisa.gov/news.xml"
+
+
+@mcp.tool()
+async def get_kev_vulnerabilities(cve_id: str = None, limit: int = 20) -> str:
+    """Get CISA Known Exploited Vulnerabilities (KEV) catalog.
+
+    Args:
+        cve_id: Filter by specific CVE ID (e.g., 'CVE-2023-4966')
+        limit: Maximum number of vulnerabilities to return (default: 20)
+
+    Returns:
+        List of known exploited vulnerabilities with details
+    """
+    try:
+        data = await fetch_json(CISA_KEV_URL)
+        vulnerabilities = data.get("vulnerabilities", [])
+        
+        if cve_id:
+            # Filter by specific CVE
+            cve_upper = cve_id.upper()
+            vulnerabilities = [
+                v for v in vulnerabilities 
+                if v.get("cveID", "").upper() == cve_upper
+            ]
+            if not vulnerabilities:
+                return f"No vulnerability found with CVE ID: {cve_id}"
+        
+        # Limit results
+        vulnerabilities = vulnerabilities[:limit]
+        
+        if not vulnerabilities:
+            return "No known exploited vulnerabilities found."
+        
+        result = [f"**CISA Known Exploited Vulnerabilities** ({len(vulnerabilities)} shown)\n"]
+        
+        for v in vulnerabilities:
+            cve = v.get("cveID", "N/A")
+            vendor = v.get("vendorProject", "N/A")
+            product = v.get("product", "N/A")
+            desc = v.get("vulnerabilityName", "N/A")
+            date_added = v.get("dateAdded", "N/A")
+            due_date = v.get("dueDate", "N/A")
+            ransomware = v.get("knownRansomwareCampaignUse", "Unknown")
+            
+            result.append(
+                f"\n**{cve}** - {desc}\n"
+                f"- Vendor: {vendor}\n"
+                f"- Product: {product}\n"
+                f"- Date Added: {date_added}\n"
+                f"- Remediation Due: {due_date}\n"
+                f"- Ransomware Campaign: {ransomware}"
+            )
+        
+        return "\n".join(result)
+        
+    except Exception as e:
+        return f"Error fetching KEV data: {str(e)}"
+
+
+@mcp.tool()
+async def get_cisa_alerts(limit: int = 10, keyword: str = None) -> str:
+    """Get CISA security alerts and advisories.
+
+    Args:
+        limit: Maximum number of alerts to return (default: 10)
+        keyword: Filter alerts by keyword in title or description
+
+    Returns:
+        List of recent CISA security alerts
+    """
+    try:
+        import xml.etree.ElementTree as ET
+        import httpx
+        
+        from mcp_govt_api.utils.http import http_client
+        
+        response = await http_client.get(CISA_ALERTS_URL)
+        response.raise_for_status()
+        
+        root = ET.fromstring(response.text)
+        
+        # Handle RSS/Atom namespace
+        ns = {
+            'atom': 'http://www.w3.org/2005/Atom',
+            'dc': 'http://purl.org/dc/elements/1.1/',
+            'content': 'http://purl.org/rss/1.0/modules/content/'
+        }
+        
+        alerts = []
+        
+        # Try Atom format first
+        entries = root.findall('.//atom:entry', ns)
+        if entries:
+            for entry in entries[:limit]:
+                title = entry.findtext('atom:title', '', ns)
+                link = entry.findtext('atom:link[@href]/@href', '', ns)
+                if not link:
+                    link_elem = entry.find('atom:link', ns)
+                    if link_elem is not None:
+                        link = link_elem.get('href', '')
+                published = entry.findtext('atom:published', '', ns)
+                summary = entry.findtext('atom:summary', '', ns)
+                
+                alerts.append({
+                    'title': title,
+                    'link': link,
+                    'date': published[:10] if published else 'N/A',
+                    'summary': summary[:200] + '...' if len(summary) > 200 else summary
+                })
+        else:
+            # Try RSS format
+            items = root.findall('.//item') or root.findall('.//channel/item')
+            for item in items[:limit]:
+                title = item.findtext('title', '')
+                link = item.findtext('link', '')
+                pub_date = item.findtext('pubDate', '')
+                desc = item.findtext('description', '')
+                
+                alerts.append({
+                    'title': title,
+                    'link': link,
+                    'date': pub_date,
+                    'summary': desc[:200] + '...' if len(desc) > 200 else desc
+                })
+        
+        # Filter by keyword if provided
+        if keyword:
+            keyword_lower = keyword.lower()
+            alerts = [
+                a for a in alerts 
+                if keyword_lower in a['title'].lower() or keyword_lower in a['summary'].lower()
+            ]
+        
+        if not alerts:
+            return "No CISA alerts found."
+        
+        result = [f"**CISA Security Alerts** ({len(alerts)} shown)\n"]
+        
+        for alert in alerts[:limit]:
+            result.append(
+                f"\n**{alert['title']}**\n"
+                f"- Date: {alert['date']}\n"
+                f"- Link: {alert['link']}\n"
+                f"- Summary: {alert['summary']}"
+            )
+        
+        return "\n".join(result)
+        
+    except Exception as e:
+        return f"Error fetching CISA alerts: {str(e)}"
+
+
+@mcp.tool()
+async def get_security_advisories(vendor: str = None, product: str = None, limit: int = 20) -> str:
+    """Get CISA security advisories filtered by vendor or product.
+
+    Args:
+        vendor: Filter by vendor name (e.g., 'Microsoft', 'Adobe')
+        product: Filter by product name
+        limit: Maximum number of advisories to return (default: 20)
+
+    Returns:
+        Filtered list of security advisories from CISA KEV catalog
+    """
+    try:
+        data = await fetch_json(CISA_KEV_URL)
+        vulnerabilities = data.get("vulnerabilities", [])
+        
+        # Apply filters
+        filtered = vulnerabilities
+        
+        if vendor:
+            vendor_lower = vendor.lower()
+            filtered = [
+                v for v in filtered 
+                if vendor_lower in v.get("vendorProject", "").lower()
+            ]
+        
+        if product:
+            product_lower = product.lower()
+            filtered = [
+                v for v in filtered 
+                if product_lower in v.get("product", "").lower()
+            ]
+        
+        # Limit results
+        filtered = filtered[:limit]
+        
+        if not filtered:
+            filters = []
+            if vendor:
+                filters.append(f"vendor='{vendor}'")
+            if product:
+                filters.append(f"product='{product}'")
+            filter_str = " and ".join(filters) if filters else "specified criteria"
+            return f"No advisories found for {filter_str}."
+        
+        result = [f"**CISA Security Advisories** ({len(filtered)} found)\n"]
+        
+        if vendor:
+            result.append(f"Vendor filter: {vendor}\n")
+        if product:
+            result.append(f"Product filter: {product}\n")
+        
+        for v in filtered:
+            cve = v.get("cveID", "N/A")
+            vendor_name = v.get("vendorProject", "N/A")
+            product_name = v.get("product", "N/A")
+            desc = v.get("vulnerabilityName", "N/A")
+            date_added = v.get("dateAdded", "N/A")
+            due_date = v.get("dueDate", "N/A")
+            required_action = v.get("requiredAction", "N/A")
+            ransomware = v.get("knownRansomwareCampaignUse", "Unknown")
+            
+            result.append(
+                f"\n**{cve}** - {desc}\n"
+                f"- Vendor: {vendor_name}\n"
+                f"- Product: {product_name}\n"
+                f"- Date Added: {date_added}\n"
+                f"- Remediation Due: {due_date}\n"
+                f"- Required Action: {required_action}\n"
+                f"- Ransomware Campaign: {ransomware}"
+            )
+        
+        return "\n".join(result)
+        
+    except Exception as e:
+        return f"Error fetching security advisories: {str(e)}"
+
+
+@mcp.tool()
+async def search_kev_by_ransomware(limit: int = 20) -> str:
+    """Get CISA KEV vulnerabilities known to be used in ransomware campaigns.
+
+    Args:
+        limit: Maximum number of vulnerabilities to return (default: 20)
+
+    Returns:
+        List of vulnerabilities actively used in ransomware attacks
+    """
+    try:
+        data = await fetch_json(CISA_KEV_URL)
+        vulnerabilities = data.get("vulnerabilities", [])
+        
+        # Filter for ransomware campaigns
+        ransomware_vulns = [
+            v for v in vulnerabilities 
+            if v.get("knownRansomwareCampaignUse", "").lower() == "known"
+        ]
+        
+        # Limit results
+        ransomware_vulns = ransomware_vulns[:limit]
+        
+        if not ransomware_vulns:
+            return "No ransomware-related vulnerabilities found in KEV catalog."
+        
+        result = [
+            f"**CISA KEV - Ransomware-Exploited Vulnerabilities** "
+            f"({len(ransomware_vulns)} shown)\n",
+            "⚠️ These vulnerabilities are known to be used in ransomware campaigns.\n"
+        ]
+        
+        for v in ransomware_vulns:
+            cve = v.get("cveID", "N/A")
+            vendor = v.get("vendorProject", "N/A")
+            product = v.get("product", "N/A")
+            desc = v.get("vulnerabilityName", "N/A")
+            date_added = v.get("dateAdded", "N/A")
+            due_date = v.get("dueDate", "N/A")
+            
+            result.append(
+                f"\n**{cve}** - {desc}\n"
+                f"- Vendor: {vendor}\n"
+                f"- Product: {product}\n"
+                f"- Date Added: {date_added}\n"
+                f"- Remediation Due: {due_date}"
+            )
+        
+        return "\n".join(result)
+        
+    except Exception as e:
+        return f"Error fetching ransomware vulnerability data: {str(e)}"
+
+
+@mcp.tool()
+async def get_critical_kev(days: int = 30, limit: int = 20) -> str:
+    """Get recently added critical CISA KEV vulnerabilities.
+
+    Args:
+        days: Number of days to look back (default: 30)
+        limit: Maximum number of vulnerabilities to return (default: 20)
+
+    Returns:
+        List of recently added critical vulnerabilities
+    """
+    try:
+        from datetime import datetime, timedelta
+        
+        data = await fetch_json(CISA_KEV_URL)
+        vulnerabilities = data.get("vulnerabilities", [])
+        
+        # Calculate cutoff date
+        cutoff = datetime.now() - timedelta(days=days)
+        
+        recent_vulns = []
+        for v in vulnerabilities:
+            date_str = v.get("dateAdded", "")
+            if date_str:
+                try:
+                    v_date = datetime.strptime(date_str, "%Y-%m-%d")
+                    if v_date >= cutoff:
+                        recent_vulns.append(v)
+                except ValueError:
+                    continue
+        
+        # Sort by date added (newest first)
+        recent_vulns.sort(key=lambda x: x.get("dateAdded", ""), reverse=True)
+        
+        # Limit results
+        recent_vulns = recent_vulns[:limit]
+        
+        if not recent_vulns:
+            return f"No vulnerabilities added in the last {days} days."
+        
+        result = [
+            f"**Recently Added CISA KEV Vulnerabilities** (last {days} days)\n",
+            f"Showing {len(recent_vulns)} of {len(recent_vulns)} recent additions:\n"
+        ]
+        
+        for v in recent_vulns:
+            cve = v.get("cveID", "N/A")
+            vendor = v.get("vendorProject", "N/A")
+            product = v.get("product", "N/A")
+            desc = v.get("vulnerabilityName", "N/A")
+            date_added = v.get("dateAdded", "N/A")
+            due_date = v.get("dueDate", "N/A")
+            ransomware = v.get("knownRansomwareCampaignUse", "Unknown")
+            
+            ransomware_flag = " 🚨 RANSOMWARE" if ransomware == "Known" else ""
+            
+            result.append(
+                f"\n**{cve}**{ransomware_flag}\n"
+                f"- Description: {desc}\n"
+                f"- Vendor: {vendor}\n"
+                f"- Product: {product}\n"
+                f"- Date Added: {date_added}\n"
+                f"- Remediation Due: {due_date}"
+            )
+        
+        return "\n".join(result)
+        
+    except Exception as e:
+        return f"Error fetching critical KEV data: {str(e)}"

--- a/src/mcp_govt_api/tools/nps.py
+++ b/src/mcp_govt_api/tools/nps.py
@@ -1,0 +1,226 @@
+from mcp_govt_api.server import mcp
+from mcp_govt_api.utils.config import config
+from mcp_govt_api.utils.http import fetch_json
+
+
+NPS_BASE = "https://developer.nps.gov/api/v1"
+
+
+def get_api_key() -> str:
+    """Return NPS API key or raise if not configured."""
+    key = config.nps_api_key
+    if not key:
+        raise Exception(
+            "NPS_API_KEY not configured. Get a free key at "
+            "https://www.nps.gov/subjects/developer/get-started.htm"
+        )
+    return key
+
+
+@mcp.tool()
+async def search_parks(
+    state: str = "",
+    query: str = "",
+    limit: int = 10
+) -> str:
+    """Search for National Parks by state, name, or keywords.
+
+    Args:
+        state: Two-letter state code (e.g., 'CA', 'NY', 'WY')
+        query: Search term for park name (e.g., 'Yellowstone', 'Grand Canyon')
+        limit: Maximum number of results (default: 10)
+
+    Returns:
+        List of parks with name, code, description, and location
+    """
+    params = {
+        "api_key": get_api_key(),
+        "limit": min(limit, 50)  # API max is 50
+    }
+
+    if state:
+        params["stateCode"] = state.upper()
+    if query:
+        params["q"] = query
+
+    data = await fetch_json(f"{NPS_BASE}/parks", params=params)
+
+    parks = data.get("data", [])
+    if not parks:
+        return "No parks found matching your criteria."
+
+    result = [f"**National Parks Search Results**\n"]
+    if state:
+        result.append(f"State: {state.upper()}")
+    if query:
+        result.append(f"Query: '{query}'")
+    result.append(f"Found {len(parks)} park(s)\n")
+
+    for park in parks:
+        states = park.get("states", "N/A")
+        result.append(
+            f"**{park.get('fullName', 'Unknown')}**\n"
+            f"Code: `{park.get('parkCode', 'N/A')}`\n"
+            f"States: {states}\n"
+            f"Description: {park.get('description', 'No description available.')[:200]}...\n"
+            f"Learn more: {park.get('url', 'N/A')}"
+        )
+
+    return "\n\n---\n\n".join(result)
+
+
+@mcp.tool()
+async def get_park_details(park_code: str) -> str:
+    """Get detailed information about a specific National Park.
+
+    Args:
+        park_code: Park code (e.g., 'yell' for Yellowstone, 'grca' for Grand Canyon)
+
+    Returns:
+        Full park details including description, activities, topics, contacts, and entrance fees
+    """
+    params = {
+        "api_key": get_api_key(),
+        "parkCode": park_code.lower()
+    }
+
+    data = await fetch_json(f"{NPS_BASE}/parks", params=params)
+
+    parks = data.get("data", [])
+    if not parks:
+        return f"Park with code '{park_code}' not found."
+
+    park = parks[0]
+
+    result = [f"**{park.get('fullName', 'Unknown Park')}**\n"]
+    result.append(f"Park Code: `{park.get('parkCode', 'N/A')}`")
+    result.append(f"States: {park.get('states', 'N/A')}")
+    result.append(f"Designation: {park.get('designation', 'N/A')}\n")
+
+    result.append(f"**Description**\n{park.get('description', 'No description available.')}\n")
+
+    # Weather info
+    weather = park.get('weatherInfo', '')
+    if weather:
+        result.append(f"**Weather**\n{weather}\n")
+
+    # Activities
+    activities = park.get('activities', [])
+    if activities:
+        activity_names = [a.get('name', '') for a in activities[:15]]
+        result.append(f"**Activities**\n{', '.join(activity_names)}\n")
+
+    # Topics
+    topics = park.get('topics', [])
+    if topics:
+        topic_names = [t.get('name', '') for t in topics[:10]]
+        result.append(f"**Topics**\n{', '.join(topic_names)}\n")
+
+    # Entrance fees
+    fees = park.get('entranceFees', [])
+    if fees:
+        result.append("**Entrance Fees**")
+        for fee in fees:
+            result.append(f"- {fee.get('title', 'Fee')}: ${fee.get('cost', '0')} - {fee.get('description', '')}")
+        result.append("")
+
+    # Operating hours
+    hours = park.get('operatingHours', [])
+    if hours:
+        result.append("**Operating Hours**")
+        for h in hours:
+            result.append(f"- {h.get('name', 'Standard Hours')}:")
+            standard_hours = h.get('standardHours', {})
+            for day, time in standard_hours.items():
+                result.append(f"  - {day.capitalize()}: {time}")
+        result.append("")
+
+    # Contacts
+    contacts = park.get('contacts', {})
+    phone_numbers = contacts.get('phoneNumbers', [])
+    if phone_numbers:
+        result.append("**Contact**")
+        for phone in phone_numbers[:2]:
+            result.append(f"- {phone.get('type', 'Phone')}: {phone.get('phoneNumber', 'N/A')}")
+        result.append("")
+
+    # Directions
+    directions = park.get('directionsInfo', '')
+    if directions:
+        result.append(f"**Directions**\n{directions[:300]}...\n")
+
+    result.append(f"**Website**: {park.get('url', 'N/A')}")
+
+    return "\n".join(result)
+
+
+@mcp.tool()
+async def get_park_alerts(park_code: str = "") -> str:
+    """Get current alerts, closures, and warnings for National Parks.
+
+    Args:
+        park_code: Optional park code to filter alerts (e.g., 'yell' for Yellowstone)
+                  If not provided, returns alerts from all parks
+
+    Returns:
+        List of active alerts with category, title, and description
+    """
+    params = {
+        "api_key": get_api_key(),
+        "limit": 50
+    }
+
+    if park_code:
+        params["parkCode"] = park_code.lower()
+
+    data = await fetch_json(f"{NPS_BASE}/alerts", params=params)
+
+    alerts = data.get("data", [])
+    if not alerts:
+        if park_code:
+            return f"No active alerts for park '{park_code}'."
+        return "No active alerts across all National Parks."
+
+    if park_code:
+        result = [f"**Park Alerts for '{park_code.upper()}'**\n"]
+    else:
+        result = [f"**National Park Alerts**\n"]
+
+    result.append(f"Found {len(alerts)} active alert(s)\n")
+
+    # Group alerts by category
+    categories = {}
+    for alert in alerts:
+        category = alert.get('category', 'General')
+        if category not in categories:
+            categories[category] = []
+        categories[category].append(alert)
+
+    # Display alerts grouped by category
+    for category, cat_alerts in categories.items():
+        result.append(f"**{category} ({len(cat_alerts)})**\n")
+        for alert in cat_alerts:
+            result.append(
+                f"- **{alert.get('title', 'Alert')}**\n"
+                f"  Park: {alert.get('fullName', 'Unknown')}\n"
+                f"  {alert.get('description', 'No details available.')}\n"
+            )
+
+    return "\n".join(result)
+
+
+@mcp.tool()
+async def query_nps(endpoint: str, params: dict | None = None) -> dict:
+    """Make a raw query to the NPS API.
+
+    Args:
+        endpoint: API endpoint (e.g., '/parks', '/alerts', '/events', '/campgrounds')
+        params: Query parameters (api_key will be added automatically)
+
+    Returns:
+        Raw JSON response from NPS API
+    """
+    url = f"{NPS_BASE}{endpoint}"
+    params = params or {}
+    params["api_key"] = get_api_key()
+    return await fetch_json(url, params=params)

--- a/src/mcp_govt_api/utils/config.py
+++ b/src/mcp_govt_api/utils/config.py
@@ -8,11 +8,14 @@ class Config:
 
     openweather_api_key: str | None = None
     nasa_api_key: str | None = None
+    bea_api_key: str | None = None
+    nps_api_key: str | None = None
     timeout: int = 30
 
     def __post_init__(self):
         self.openweather_api_key = os.environ.get("OPENWEATHER_API_KEY")
         self.nasa_api_key = os.environ.get("NASA_API_KEY")
+        self.bea_api_key = os.environ.get("BEA_API_KEY")
         self.timeout = int(os.environ.get("API_TIMEOUT", "30"))
 
     @property
@@ -47,6 +50,7 @@ class Config:
             "  ✓ USGS Water (no key required)",
             "  ✓ USGS Earthquakes (no key required)",
             "  ✓ NOAA Space Weather (no key required)",
+            "  ✓ CISA KEV Catalog (no key required)",
         ])
         if self.has_nasa_key:
             lines.append("  ✓ NASA FIRMS (using NASA API key)")

--- a/src/mcp_govt_api/utils/config.py
+++ b/src/mcp_govt_api/utils/config.py
@@ -16,6 +16,7 @@ class Config:
         self.openweather_api_key = os.environ.get("OPENWEATHER_API_KEY")
         self.nasa_api_key = os.environ.get("NASA_API_KEY")
         self.bea_api_key = os.environ.get("BEA_API_KEY")
+        self.nps_api_key = os.environ.get("NPS_API_KEY")
         self.timeout = int(os.environ.get("API_TIMEOUT", "30"))
 
     @property


### PR DESCRIPTION
Closes #84

## Summary
Adds National Park Service integration with tools for park information, alerts, and closures.

## Tools Added
- `search_parks(state, query, limit)` - Search parks by state, name, or keywords
- `get_park_details(park_code)` - Get detailed park info (activities, fees, hours, contacts)
- `get_park_alerts(park_code)` - Get park alerts, closures, and warnings
- `query_nps(endpoint, params)` - Raw NPS API access

## Configuration
Requires `NPS_API_KEY` environment variable. Get free key at https://www.nps.gov/subjects/developer/get-started.htm

## Changes
- New: `src/mcp_govt_api/tools/nps.py` - NPS tools module
- Updated: `src/mcp_govt_api/utils/config.py` - Added NPS_API_KEY config
- Updated: `src/mcp_govt_api/tools/__init__.py` - Import nps module
- Updated: `README.md` - Added NPS documentation