### PR TITLE
Fix HTTP client not properly closed on server shutdown

### DIFF
--- a/src/mcp_govt_api/server.py
+++ b/src/mcp_govt_api/server.py
@@ -1,9 +1,11 @@
 from mcp.server.fastmcp import FastMCP
 
 from mcp_govt_api.utils.config import config
+from mcp_govt_api.utils.http import http_lifespan
 
 mcp = FastMCP(
     "Government API Server",
+    lifespan=http_lifespan,
     instructions="""Access free government and open data APIs including:
 - NOAA Weather (US forecasts and alerts)
 - OpenWeather (global weather, requires API key)

--- a/src/mcp_govt_api/utils/http.py
+++ b/src/mcp_govt_api/utils/http.py
@@ -1,5 +1,7 @@
 import httpx
 from typing import Any
+from contextlib import asynccontextmanager
+from collections.abc import AsyncIterator
 
 from mcp_govt_api.utils.config import config
 
@@ -9,6 +11,15 @@ http_client = httpx.AsyncClient(
     follow_redirects=True,
     headers={"User-Agent": "mcp-civic-data/0.1.0"},
 )
+
+
+@asynccontextmanager
+async def http_lifespan(_server: Any) -> AsyncIterator[None]:
+    """Lifespan context manager that closes the HTTP client on shutdown."""
+    try:
+        yield None
+    finally:
+        await http_client.aclose()
 
 
 async def fetch_json(url: str, params: dict[str, Any] | None = None) -> Any:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,5 +1,6 @@
 """Basic import tests for MCP Civic Data."""
 
+import asyncio
 import unittest
 
 
@@ -11,6 +12,34 @@ class TestHTTPUtils(unittest.TestCase):
         from mcp_govt_api.utils import http
 
         self.assertIsNotNone(http)
+
+
+class TestHTTPClientLifecycle(unittest.TestCase):
+    """Tests for HTTP client lifecycle management."""
+
+    def test_http_lifespan_closes_client(self):
+        """Test that http_lifespan context manager closes the HTTP client."""
+        from mcp_govt_api.utils.http import http_lifespan, http_client
+
+        async def run():
+            # Client should start open
+            assert not http_client.is_closed
+
+            async with http_lifespan(None):
+                # Client should still be open during lifespan
+                assert not http_client.is_closed
+
+            # Client should be closed after lifespan exits
+            assert http_client.is_closed
+
+        asyncio.run(run())
+
+    def test_server_has_lifespan_configured(self):
+        """Test that the MCP server is configured with the HTTP lifespan."""
+        from mcp_govt_api.server import mcp
+        from mcp_govt_api.utils.http import http_lifespan
+
+        self.assertEqual(mcp.settings.lifespan, http_lifespan)
 
 
 class TestConfig(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Adds `http_lifespan` async context manager to properly close the httpx AsyncClient on server shutdown
- Hooks into FastMCP's native lifespan mechanism via the `lifespan` parameter
- Adds tests verifying client lifecycle and server configuration

## Test plan
- [x] `test_http_lifespan_closes_client` — verifies client is open during lifespan and closed after exit
- [x] `test_server_has_lifespan_configured` — verifies MCP server has lifespan set
- [x] All existing tests still pass

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)