### PR TITLE
Add FRED economic indicators tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@
 # NASA API (optional - enables NASA tools with higher rate limits)
 # NASA_API_KEY=your_nasa_api_key
 
+# FRED API (required for FRED economic data tools)
+# Get a free key at https://fred.stlouisfed.org/docs/api/api_key.html
+# FRED_API_KEY=your_fred_api_key
+
 # API Timeout (seconds)
 API_TIMEOUT=30
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
 [![CI](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml/badge.svg)](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml)
-[![51 Tools](https://img.shields.io/badge/tools-51-2563eb.svg?style=flat-square)](#tool-reference)
-[![15 APIs](https://img.shields.io/badge/APIs-15-7c3aed.svg?style=flat-square)](#data-sources)
+[![54 Tools](https://img.shields.io/badge/tools-54-2563eb.svg?style=flat-square)](#tool-reference)
+[![16 APIs](https://img.shields.io/badge/APIs-16-7c3aed.svg?style=flat-square)](#data-sources)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776ab.svg?style=flat-square)](https://python.org)
 [![MCP](https://img.shields.io/badge/protocol-MCP-f97316.svg?style=flat-square)](https://modelcontextprotocol.io)
 
-An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **15 free, authoritative public data APIs** across weather, hazards, air quality, water, radiation, demographics, economics, open data discovery, cybersecurity, and SEC disclosures.
+An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **16 free, authoritative public data APIs** across weather, hazards, air quality, water, radiation, demographics, economics, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
 
 Built for practical agent workflows: concise high-level tools, raw query access where it matters, and location-aware inputs that accept city names, ZIP codes, addresses, or raw coordinates.
 
-No API keys required for 13 of 15 sources. Install it, point your MCP client at it, and start querying real civic data.
+No API keys required for 13 of 16 sources. Install it, point your MCP client at it, and start querying real civic data.
 
 [Get Started](#get-started) · [What's New](#whats-new) · [Data Sources](#data-sources) · [Tool Reference](#tool-reference) · [Roadmap](#implementation-roadmap) · [Contributing](CONTRIBUTING.md)
 
@@ -35,7 +35,8 @@ No API keys required for 13 of 15 sources. Install it, point your MCP client at 
       "args": ["-m", "mcp_govt_api"],
       "env": {
         "OPENWEATHER_API_KEY": "optional",
-        "NASA_API_KEY": "optional"
+        "NASA_API_KEY": "optional",
+        "FRED_API_KEY": "optional"
       }
     }
   }
@@ -90,6 +91,7 @@ python3 -m mcp_govt_api
 |--------|---------------|-----|
 | [US Census](https://census.gov) | Population, demographics, housing for every US county | -- |
 | [World Bank](https://worldbank.org) | GDP, poverty, unemployment for 200+ countries | -- |
+| [FRED](https://fred.stlouisfed.org) | Federal Reserve economic data: GDP, inflation, employment, interest rates | Required |
 
 ### Finance & Securities
 
@@ -124,6 +126,8 @@ python3 -m mcp_govt_api
 "What are the radiation levels near Fukushima?"
 "What are stream flow levels in Colorado?"
 "Find datasets about climate change on Data.gov"
+"What's the current US GDP from FRED?"
+"Search FRED for unemployment rate data"
 "Get Apple's latest 10-K filing from SEC"
 "Show me recent SEC filings for Tesla"
 "Are there any known exploited vulnerabilities for Microsoft products?"
@@ -263,13 +267,24 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 </details>
 
 <details>
-<summary><strong>Economics</strong> — 3 tools</summary>
+<summary><strong>Economics (World Bank)</strong> — 3 tools</summary>
 
 | Tool | Description |
 |------|-------------|
 | `get_country_indicators` | GDP, population, poverty for any country |
 | `compare_countries` | Compare indicators across multiple countries |
 | `query_worldbank` | Raw World Bank API access |
+
+</details>
+
+<details>
+<summary><strong>Economics (FRED)</strong> — 3 tools</summary>
+
+| Tool | Description |
+|------|-------------|
+| `search_fred_series` | Search for economic data series by keyword |
+| `get_fred_series` | Get observations for a series (e.g., GDP, UNRATE, CPIAUCSL) |
+| `get_fred_series_info` | Get metadata about a series |
 
 </details>
 
@@ -320,6 +335,7 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 |----------|---------|---------|
 | `OPENWEATHER_API_KEY` | Enables global weather tools | *(disabled)* |
 | `NASA_API_KEY` | Higher rate limits for NASA + FIRMS | `DEMO_KEY` (30 req/hr) |
+| `FRED_API_KEY` | Enables FRED economic data tools | *(disabled)* |
 | `API_TIMEOUT` | Request timeout in seconds | `30` |
 
 On startup the server prints which APIs are available:

--- a/src/mcp_govt_api/server.py
+++ b/src/mcp_govt_api/server.py
@@ -20,6 +20,7 @@ mcp = FastMCP(
 - NOAA Space Weather (solar wind, flares, geomagnetic storms)
 - CISA (cybersecurity advisories, known exploited vulnerabilities)
 - SEC EDGAR (company filings, submissions, and company facts)
+- FRED (Federal Reserve economic data, time series, indicators)
 """,
 )
 
@@ -46,3 +47,4 @@ from mcp_govt_api.tools import firms  # noqa: E402, F401
 from mcp_govt_api.tools import space_weather  # noqa: E402, F401
 from mcp_govt_api.tools import cisa  # noqa: E402, F401
 from mcp_govt_api.tools import sec  # noqa: E402, F401
+from mcp_govt_api.tools import fred  # noqa: E402, F401

--- a/src/mcp_govt_api/tools/fred.py
+++ b/src/mcp_govt_api/tools/fred.py
@@ -1,0 +1,159 @@
+from mcp_govt_api.server import mcp
+from mcp_govt_api.utils.config import config
+from mcp_govt_api.utils.http import fetch_json
+
+
+FRED_BASE = "https://api.stlouisfed.org/fred"
+
+
+def get_api_key() -> str:
+    """Return FRED API key or raise an error if not configured."""
+    if not config.fred_api_key:
+        raise ValueError(
+            "FRED_API_KEY is not set. "
+            "Get a free key at https://fred.stlouisfed.org/docs/api/api_key.html"
+        )
+    return config.fred_api_key
+
+
+@mcp.tool()
+async def search_fred_series(query: str, limit: int = 10) -> str:
+    """Search for FRED economic data series by keyword.
+
+    Args:
+        query: Search terms (e.g., 'GDP', 'unemployment rate', 'consumer price index')
+        limit: Maximum number of results to return (default: 10)
+
+    Returns:
+        Matching series with IDs, titles, and descriptions
+    """
+    try:
+        api_key = get_api_key()
+    except ValueError as exc:
+        return str(exc)
+
+    params = {
+        "search_text": query,
+        "api_key": api_key,
+        "file_type": "json",
+        "limit": limit,
+    }
+
+    try:
+        data = await fetch_json(f"{FRED_BASE}/series/search", params=params)
+    except Exception as exc:
+        return f"Error searching FRED: {exc}"
+
+    series_list = data.get("seriess", [])
+    if not series_list:
+        return f"No FRED series found for '{query}'"
+
+    result = [f"**FRED Series Search: '{query}'**\n"]
+    result.append(f"Found {data.get('count', len(series_list))} total results "
+                  f"(showing {len(series_list)})\n")
+
+    for s in series_list:
+        frequency = s.get("frequency", "N/A")
+        units = s.get("units", "N/A")
+        seasonal = s.get("seasonal_adjustment", "N/A")
+        obs_start = s.get("observation_start", "N/A")
+        obs_end = s.get("observation_end", "N/A")
+        result.append(
+            f"**{s.get('title', 'Untitled')}**\n"
+            f"  Series ID: {s.get('id', 'N/A')}\n"
+            f"  Frequency: {frequency} | Units: {units}\n"
+            f"  Seasonal Adjustment: {seasonal}\n"
+            f"  Date Range: {obs_start} to {obs_end}"
+        )
+
+    return "\n\n".join(result)
+
+
+@mcp.tool()
+async def get_fred_series(series_id: str, limit: int = 10) -> str:
+    """Get observations (data points) for a FRED economic data series.
+
+    Args:
+        series_id: FRED series ID (e.g., 'GDP', 'UNRATE', 'CPIAUCSL', 'DFF')
+        limit: Number of most recent observations to return (default: 10)
+
+    Returns:
+        Recent data points with dates and values
+    """
+    try:
+        api_key = get_api_key()
+    except ValueError as exc:
+        return str(exc)
+
+    params = {
+        "series_id": series_id,
+        "api_key": api_key,
+        "file_type": "json",
+        "sort_order": "desc",
+        "limit": limit,
+    }
+
+    try:
+        data = await fetch_json(
+            f"{FRED_BASE}/series/observations", params=params
+        )
+    except Exception as exc:
+        return f"Error fetching FRED series '{series_id}': {exc}"
+
+    observations = data.get("observations", [])
+    if not observations:
+        return f"No observations found for series '{series_id}'"
+
+    result = [f"**FRED Series: {series_id}**\n"]
+    result.append(f"Showing {len(observations)} most recent observations\n")
+
+    for obs in observations:
+        date = obs.get("date", "N/A")
+        value = obs.get("value", "N/A")
+        result.append(f"  {date}: {value}")
+
+    return "\n".join(result)
+
+
+@mcp.tool()
+async def get_fred_series_info(series_id: str) -> str:
+    """Get metadata about a FRED economic data series.
+
+    Args:
+        series_id: FRED series ID (e.g., 'GDP', 'UNRATE', 'CPIAUCSL')
+
+    Returns:
+        Series title, frequency, units, seasonal adjustment, and date range
+    """
+    try:
+        api_key = get_api_key()
+    except ValueError as exc:
+        return str(exc)
+
+    params = {
+        "series_id": series_id,
+        "api_key": api_key,
+        "file_type": "json",
+    }
+
+    try:
+        data = await fetch_json(f"{FRED_BASE}/series", params=params)
+    except Exception as exc:
+        return f"Error fetching FRED series info for '{series_id}': {exc}"
+
+    series_list = data.get("seriess", [])
+    if not series_list:
+        return f"No series found with ID '{series_id}'"
+
+    s = series_list[0]
+    return (
+        f"**{s.get('title', 'Untitled')}**\n"
+        f"Series ID: {s.get('id', 'N/A')}\n"
+        f"Frequency: {s.get('frequency', 'N/A')}\n"
+        f"Units: {s.get('units', 'N/A')}\n"
+        f"Seasonal Adjustment: {s.get('seasonal_adjustment', 'N/A')}\n"
+        f"Date Range: {s.get('observation_start', 'N/A')} to "
+        f"{s.get('observation_end', 'N/A')}\n"
+        f"Last Updated: {s.get('last_updated', 'N/A')}\n"
+        f"Notes: {s.get('notes', 'N/A')[:500]}"
+    )

--- a/src/mcp_govt_api/utils/config.py
+++ b/src/mcp_govt_api/utils/config.py
@@ -8,11 +8,13 @@ class Config:
 
     openweather_api_key: str | None = None
     nasa_api_key: str | None = None
+    fred_api_key: str | None = None
     timeout: int = 30
 
     def __post_init__(self):
         self.openweather_api_key = os.environ.get("OPENWEATHER_API_KEY")
         self.nasa_api_key = os.environ.get("NASA_API_KEY")
+        self.fred_api_key = os.environ.get("FRED_API_KEY")
         self.timeout = int(os.environ.get("API_TIMEOUT", "30"))
 
     @property
@@ -22,6 +24,10 @@ class Config:
     @property
     def has_nasa_key(self) -> bool:
         return bool(self.nasa_api_key)
+
+    @property
+    def has_fred(self) -> bool:
+        return bool(self.fred_api_key)
 
     def get_availability_summary(self) -> str:
         """Return a summary of API availability."""
@@ -50,6 +56,10 @@ class Config:
             "  ✓ SEC EDGAR (no key required)",
             "  ✓ CISA (no key required)",
         ])
+        if self.has_fred:
+            lines.append("  ✓ FRED (API key configured)")
+        else:
+            lines.append("  ✗ FRED (FRED_API_KEY not set)")
         if self.has_nasa_key:
             lines.append("  ✓ NASA FIRMS (using NASA API key)")
         else:

--- a/tests/test_fred.py
+++ b/tests/test_fred.py
@@ -1,0 +1,162 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from mcp_govt_api.tools.fred import (
+    get_fred_series,
+    get_fred_series_info,
+    search_fred_series,
+)
+
+
+class FredToolTests(unittest.IsolatedAsyncioTestCase):
+    @patch("mcp_govt_api.tools.fred.config")
+    @patch(
+        "mcp_govt_api.tools.fred.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_search_fred_series_returns_results(self, mock_fetch, mock_config):
+        mock_config.fred_api_key = "test-key"
+        mock_fetch.return_value = {
+            "count": 1,
+            "seriess": [
+                {
+                    "id": "GDP",
+                    "title": "Gross Domestic Product",
+                    "frequency": "Quarterly",
+                    "units": "Billions of Dollars",
+                    "seasonal_adjustment": "Seasonally Adjusted Annual Rate",
+                    "observation_start": "1947-01-01",
+                    "observation_end": "2024-10-01",
+                }
+            ],
+        }
+
+        result = await search_fred_series("GDP", limit=5)
+
+        self.assertIn("Gross Domestic Product", result)
+        self.assertIn("GDP", result)
+        self.assertIn("Quarterly", result)
+        self.assertIn("Billions of Dollars", result)
+        mock_fetch.assert_awaited_once()
+        call_args = mock_fetch.call_args
+        self.assertEqual(call_args.kwargs["params"]["search_text"], "GDP")
+        self.assertEqual(call_args.kwargs["params"]["limit"], 5)
+
+    @patch("mcp_govt_api.tools.fred.config")
+    @patch(
+        "mcp_govt_api.tools.fred.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_search_fred_series_no_results(self, mock_fetch, mock_config):
+        mock_config.fred_api_key = "test-key"
+        mock_fetch.return_value = {"count": 0, "seriess": []}
+
+        result = await search_fred_series("xyznonexistent")
+
+        self.assertIn("No FRED series found", result)
+
+    @patch("mcp_govt_api.tools.fred.config")
+    @patch(
+        "mcp_govt_api.tools.fred.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_get_fred_series_returns_observations(self, mock_fetch, mock_config):
+        mock_config.fred_api_key = "test-key"
+        mock_fetch.return_value = {
+            "observations": [
+                {"date": "2024-10-01", "value": "29351.9"},
+                {"date": "2024-07-01", "value": "28850.1"},
+            ]
+        }
+
+        result = await get_fred_series("GDP", limit=2)
+
+        self.assertIn("FRED Series: GDP", result)
+        self.assertIn("2024-10-01", result)
+        self.assertIn("29351.9", result)
+        self.assertIn("2024-07-01", result)
+        mock_fetch.assert_awaited_once()
+        call_args = mock_fetch.call_args
+        self.assertEqual(call_args.kwargs["params"]["series_id"], "GDP")
+        self.assertEqual(call_args.kwargs["params"]["sort_order"], "desc")
+
+    @patch("mcp_govt_api.tools.fred.config")
+    @patch(
+        "mcp_govt_api.tools.fred.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_get_fred_series_no_observations(self, mock_fetch, mock_config):
+        mock_config.fred_api_key = "test-key"
+        mock_fetch.return_value = {"observations": []}
+
+        result = await get_fred_series("BADID")
+
+        self.assertIn("No observations found", result)
+
+    @patch("mcp_govt_api.tools.fred.config")
+    @patch(
+        "mcp_govt_api.tools.fred.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_get_fred_series_info_returns_metadata(self, mock_fetch, mock_config):
+        mock_config.fred_api_key = "test-key"
+        mock_fetch.return_value = {
+            "seriess": [
+                {
+                    "id": "UNRATE",
+                    "title": "Unemployment Rate",
+                    "frequency": "Monthly",
+                    "units": "Percent",
+                    "seasonal_adjustment": "Seasonally Adjusted",
+                    "observation_start": "1948-01-01",
+                    "observation_end": "2024-12-01",
+                    "last_updated": "2025-01-10 07:46:01-06",
+                    "notes": "The unemployment rate represents the number...",
+                }
+            ]
+        }
+
+        result = await get_fred_series_info("UNRATE")
+
+        self.assertIn("Unemployment Rate", result)
+        self.assertIn("UNRATE", result)
+        self.assertIn("Monthly", result)
+        self.assertIn("Percent", result)
+        self.assertIn("Seasonally Adjusted", result)
+        self.assertIn("1948-01-01", result)
+        mock_fetch.assert_awaited_once()
+
+    @patch("mcp_govt_api.tools.fred.config")
+    async def test_missing_api_key_returns_error(self, mock_config):
+        mock_config.fred_api_key = None
+
+        result = await search_fred_series("GDP")
+        self.assertIn("FRED_API_KEY is not set", result)
+
+        result = await get_fred_series("GDP")
+        self.assertIn("FRED_API_KEY is not set", result)
+
+        result = await get_fred_series_info("GDP")
+        self.assertIn("FRED_API_KEY is not set", result)
+
+    @patch("mcp_govt_api.tools.fred.config")
+    @patch(
+        "mcp_govt_api.tools.fred.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_fetch_error_handled_gracefully(self, mock_fetch, mock_config):
+        mock_config.fred_api_key = "test-key"
+        mock_fetch.side_effect = Exception("Connection timeout")
+
+        result = await search_fred_series("GDP")
+        self.assertIn("Error searching FRED", result)
+
+        result = await get_fred_series("GDP")
+        self.assertIn("Error fetching FRED series", result)
+
+        result = await get_fred_series_info("GDP")
+        self.assertIn("Error fetching FRED series info", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds 3 new tools for Federal Reserve Economic Data (FRED): `search_fred_series`, `get_fred_series`, `get_fred_series_info`
- Adds `FRED_API_KEY` to config with optional key pattern
- Includes 7 unit tests with mocked API responses
- Updates README with new data source, tool reference, and example queries

## Test plan
- [x] All 14 tests pass (7 new FRED + 7 existing)
- [x] `python -m compileall src` passes
- [ ] Manual test with real FRED API key

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)