### PR TITLE
Complete SEC EDGAR ticker-to-CIK lookup implementation

### DIFF
--- a/src/mcp_govt_api/tools/sec.py
+++ b/src/mcp_govt_api/tools/sec.py
@@ -1,16 +1,64 @@
 """SEC EDGAR API tools for company filings and disclosures."""
 
+import time
+
 from mcp_govt_api.server import mcp
 from mcp_govt_api.utils.http import http_client
 
 
 SEC_BASE = "https://data.sec.gov"
-CIK_LOOKUP_URL = "https://www.sec.gov/cgi-bin/browse-edgar"
+TICKERS_URL = "https://www.sec.gov/files/company_tickers.json"
+
+# In-memory cache for ticker-to-CIK mapping
+_ticker_cache: dict[str, dict] = {}  # ticker -> {"cik": str, "name": str}
+_ticker_cache_time: float = 0.0
+_CACHE_TTL = 3600  # Refresh cache every hour
 
 
 def _pad_cik(cik: str) -> str:
     """Pad CIK to 10 digits with leading zeros."""
     return cik.zfill(10)
+
+
+async def _load_ticker_cache() -> None:
+    """Fetch the SEC company tickers JSON and populate the cache.
+
+    The SEC endpoint returns a JSON object keyed by index, each entry
+    containing ``cik_str``, ``ticker``, and ``title``.  We build a
+    dictionary keyed by upper-case ticker for O(1) lookups.
+    """
+    global _ticker_cache, _ticker_cache_time
+
+    now = time.monotonic()
+    if _ticker_cache and (now - _ticker_cache_time) < _CACHE_TTL:
+        return  # Cache is still fresh
+
+    headers = {"User-Agent": "mcp-civic-data/0.1.0"}
+    response = await http_client.get(TICKERS_URL, headers=headers)
+    response.raise_for_status()
+    data = response.json()
+
+    new_cache: dict[str, dict] = {}
+    for entry in data.values():
+        ticker_key = str(entry.get("ticker", "")).upper()
+        if ticker_key:
+            new_cache[ticker_key] = {
+                "cik": str(entry.get("cik_str", "")),
+                "name": entry.get("title", ""),
+            }
+
+    _ticker_cache = new_cache
+    _ticker_cache_time = now
+
+
+async def _resolve_ticker(ticker: str) -> dict | None:
+    """Resolve a ticker symbol to its CIK and company name.
+
+    Returns a dict with ``cik`` and ``name`` keys, or ``None`` if the
+    ticker is not found.  The lookup is case-insensitive.
+    """
+    await _load_ticker_cache()
+    return _ticker_cache.get(ticker.upper())
 
 
 @mcp.tool()
@@ -28,28 +76,18 @@ async def get_company_filings(ticker: str = "", cik: str = "") -> str:
         return "Error: Please provide either a ticker symbol or CIK number."
 
     try:
-        # Get company data using ticker or CIK
-        if ticker:
-            # First, lookup CIK from ticker
-            ticker_upper = ticker.upper()
-            lookup_url = f"{SEC_BASE}/submissions/CIK0000000000.json"
-            headers = {"User-Agent": "mcp-civic-data/0.1.0"}
-            
-            # Try to get from ticker-CIK mapping via submissions endpoint
-            # First we need to find the CIK from the ticker
-            submissions_data = None
-            
-            # Use a public ticker-to-CIK lookup approach via SEC submissions
-            sub_url = f"{SEC_BASE}/submissions/CIK0000000000.json"
-            response = await http_client.get(sub_url, headers=headers)
-            
-            # If that doesn't work, try company facts with a search approach
-            # For now, we'll need user to provide CIK for reliable lookup
-            return (
-                f"To look up {ticker}, please use the CIK number.\n"
-                f"You can find CIK numbers at: https://www.sec.gov/edgar/searchedgar/cik"
-            )
-        
+        # Resolve ticker to CIK if needed
+        if ticker and not cik:
+            resolved = await _resolve_ticker(ticker)
+            if resolved is None:
+                return (
+                    f"Error: Ticker '{ticker.upper()}' not found in SEC database.\n"
+                    f"Please verify the ticker symbol or provide a CIK number directly.\n"
+                    f"You can search for CIK numbers at: "
+                    f"https://www.sec.gov/cgi-bin/browse-edgar?company=&CIK={ticker.upper()}&type=&dateb=&owner=include&count=40&search_text=&action=getcompany"
+                )
+            cik = resolved["cik"]
+
         # Use provided CIK
         cik_padded = _pad_cik(cik)
         submissions_url = f"{SEC_BASE}/submissions/CIK{cik_padded}.json"
@@ -116,34 +154,58 @@ async def search_company(name: str = "", ticker: str = "") -> str:
     """
     if not name and not ticker:
         return "Error: Please provide either a company name or ticker symbol."
-    
+
     try:
-        # Note: SEC doesn't have a direct search API for company names
-        # We'll provide guidance on how to find CIK numbers
-        
         if ticker:
-            ticker_upper = ticker.upper()
-            return (
-                f"**Company Search for Ticker: {ticker_upper}**\n\n"
-                f"To find the CIK for {ticker_upper}:\n"
-                f"1. Visit: https://www.sec.gov/edgar/searchedgar/cik\n"
-                f"2. Enter ticker: {ticker_upper}\n"
-                f"3. Use the CIK number with `get_company_filings` or `get_latest_submissions`\n\n"
-                f"Alternatively, visit:\n"
-                f"https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK={ticker_upper}&type=&dateb=&owner=include&count=40"
-            )
-        
+            resolved = await _resolve_ticker(ticker)
+            if resolved is not None:
+                cik_str = resolved["cik"]
+                company_name = resolved["name"]
+                cik_padded = _pad_cik(cik_str)
+                return (
+                    f"**Company Found: {company_name}**\n\n"
+                    f"Ticker: {ticker.upper()}\n"
+                    f"CIK: {cik_str}\n\n"
+                    f"Use this CIK with:\n"
+                    f"- `get_company_filings(cik=\"{cik_str}\")` for recent filings\n"
+                    f"- `get_latest_submissions(cik=\"{cik_str}\")` for submissions\n"
+                    f"- `get_company_facts(cik=\"{cik_str}\")` for financial data\n\n"
+                    f"EDGAR page: https://www.sec.gov/cgi-bin/browse-edgar?action=getcompany&CIK={cik_padded}&type=&dateb=&owner=include&count=40"
+                )
+            else:
+                return (
+                    f"Error: Ticker '{ticker.upper()}' not found in SEC database.\n"
+                    f"Please verify the ticker symbol or try searching by company name."
+                )
+
         if name:
-            return (
-                f"**Company Search for: {name}**\n\n"
-                f"To find the CIK for '{name}':\n"
-                f"1. Visit: https://www.sec.gov/edgar/searchedgar/cik\n"
-                f"2. Search for: {name}\n"
-                f"3. Use the CIK number with `get_company_filings` or `get_latest_submissions`\n\n"
-                f"Alternatively, use the SEC company search:\n"
-                f"https://www.sec.gov/edgar/searchedgar/companysearch"
-            )
-            
+            # Search the ticker cache for matching company names
+            await _load_ticker_cache()
+            name_lower = name.lower()
+            matches: list[dict] = []
+            for tick, info in _ticker_cache.items():
+                if name_lower in info["name"].lower():
+                    matches.append({"ticker": tick, **info})
+                if len(matches) >= 10:
+                    break
+
+            if matches:
+                result = [f"**Company Search Results for: {name}**\n"]
+                for m in matches:
+                    result.append(
+                        f"- **{m['name']}** | Ticker: {m['ticker']} | CIK: {m['cik']}"
+                    )
+                result.append(
+                    f"\nUse the CIK number with `get_company_filings` or `get_latest_submissions`."
+                )
+                return "\n".join(result)
+            else:
+                return (
+                    f"**No results found for: {name}**\n\n"
+                    f"Try a different search term, or search directly:\n"
+                    f"https://www.sec.gov/cgi-bin/browse-edgar?company={name}&CIK=&type=&dateb=&owner=include&count=40&search_text=&action=getcompany"
+                )
+
     except Exception as e:
         return f"Error searching for company: {str(e)}"
 

--- a/tests/test_sec.py
+++ b/tests/test_sec.py
@@ -1,0 +1,221 @@
+"""Tests for SEC EDGAR ticker-to-CIK resolution and tool functions."""
+
+import time
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from mcp_govt_api.tools import sec
+
+
+# Sample data mirroring SEC's company_tickers.json structure
+SAMPLE_TICKERS_JSON = {
+    "0": {"cik_str": "320193", "ticker": "AAPL", "title": "Apple Inc."},
+    "1": {"cik_str": "789019", "ticker": "MSFT", "title": "Microsoft Corp"},
+    "2": {"cik_str": "1018724", "ticker": "AMZN", "title": "Amazon Com Inc"},
+    "3": {"cik_str": "1652044", "ticker": "GOOG", "title": "Alphabet Inc."},
+    "4": {"cik_str": "1326801", "ticker": "META", "title": "Meta Platforms, Inc."},
+}
+
+
+def _make_response(json_data, status_code=200):
+    """Create a mock httpx response."""
+    resp = MagicMock()
+    resp.json.return_value = json_data
+    resp.status_code = status_code
+    resp.raise_for_status = MagicMock()
+    return resp
+
+
+class TestPadCik(unittest.TestCase):
+    """Tests for the _pad_cik helper."""
+
+    def test_short_cik(self):
+        self.assertEqual(sec._pad_cik("320193"), "0000320193")
+
+    def test_already_padded(self):
+        self.assertEqual(sec._pad_cik("0000320193"), "0000320193")
+
+    def test_single_digit(self):
+        self.assertEqual(sec._pad_cik("1"), "0000000001")
+
+    def test_empty_string(self):
+        self.assertEqual(sec._pad_cik(""), "0000000000")
+
+
+class TestTickerCache(unittest.IsolatedAsyncioTestCase):
+    """Tests for the ticker cache loading and resolution."""
+
+    def setUp(self):
+        sec._ticker_cache = {}
+        sec._ticker_cache_time = 0.0
+
+    @patch("mcp_govt_api.tools.sec.http_client")
+    async def test_load_ticker_cache_populates_cache(self, mock_client):
+        mock_client.get = AsyncMock(return_value=_make_response(SAMPLE_TICKERS_JSON))
+
+        await sec._load_ticker_cache()
+
+        self.assertIn("AAPL", sec._ticker_cache)
+        self.assertEqual(sec._ticker_cache["AAPL"]["cik"], "320193")
+        self.assertEqual(sec._ticker_cache["AAPL"]["name"], "Apple Inc.")
+        self.assertEqual(len(sec._ticker_cache), 5)
+
+    @patch("mcp_govt_api.tools.sec.http_client")
+    async def test_cache_ttl_skips_refetch(self, mock_client):
+        """Cache should not refetch if within TTL."""
+        mock_client.get = AsyncMock(return_value=_make_response(SAMPLE_TICKERS_JSON))
+
+        await sec._load_ticker_cache()
+        self.assertEqual(mock_client.get.call_count, 1)
+
+        # Second call should use cache (no new HTTP request)
+        await sec._load_ticker_cache()
+        self.assertEqual(mock_client.get.call_count, 1)
+
+    @patch("mcp_govt_api.tools.sec.http_client")
+    async def test_cache_expired_refetches(self, mock_client):
+        """Cache should refetch after TTL expires."""
+        mock_client.get = AsyncMock(return_value=_make_response(SAMPLE_TICKERS_JSON))
+
+        await sec._load_ticker_cache()
+        self.assertEqual(mock_client.get.call_count, 1)
+
+        # Simulate cache expiry
+        sec._ticker_cache_time = time.monotonic() - sec._CACHE_TTL - 1
+        await sec._load_ticker_cache()
+        self.assertEqual(mock_client.get.call_count, 2)
+
+    @patch("mcp_govt_api.tools.sec.http_client")
+    async def test_resolve_ticker_found(self, mock_client):
+        mock_client.get = AsyncMock(return_value=_make_response(SAMPLE_TICKERS_JSON))
+
+        result = await sec._resolve_ticker("AAPL")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["cik"], "320193")
+        self.assertEqual(result["name"], "Apple Inc.")
+
+    @patch("mcp_govt_api.tools.sec.http_client")
+    async def test_resolve_ticker_case_insensitive(self, mock_client):
+        mock_client.get = AsyncMock(return_value=_make_response(SAMPLE_TICKERS_JSON))
+
+        result = await sec._resolve_ticker("aapl")
+        self.assertIsNotNone(result)
+        self.assertEqual(result["cik"], "320193")
+
+        result2 = await sec._resolve_ticker("Msft")
+        self.assertIsNotNone(result2)
+        self.assertEqual(result2["cik"], "789019")
+
+    @patch("mcp_govt_api.tools.sec.http_client")
+    async def test_resolve_ticker_not_found(self, mock_client):
+        mock_client.get = AsyncMock(return_value=_make_response(SAMPLE_TICKERS_JSON))
+
+        result = await sec._resolve_ticker("ZZZZZ")
+        self.assertIsNone(result)
+
+
+class TestGetCompanyFilings(unittest.IsolatedAsyncioTestCase):
+    """Tests for the get_company_filings tool."""
+
+    def setUp(self):
+        sec._ticker_cache = {}
+        sec._ticker_cache_time = 0.0
+
+    async def test_no_args_returns_error(self):
+        result = await sec.get_company_filings()
+        self.assertIn("Error", result)
+
+    @patch("mcp_govt_api.tools.sec.http_client")
+    async def test_ticker_resolves_to_filings(self, mock_client):
+        """Providing a ticker should resolve CIK and return filings."""
+        submissions_data = {
+            "name": "Apple Inc.",
+            "cik": "320193",
+            "filings": {
+                "recent": {
+                    "form": ["10-K", "10-Q"],
+                    "filingDate": ["2024-11-01", "2024-08-02"],
+                    "primaryDocDescription": ["Annual Report", "Quarterly Report"],
+                    "accessionNumber": [
+                        "0000320193-24-000001",
+                        "0000320193-24-000002",
+                    ],
+                }
+            },
+        }
+
+        async def mock_get(url, **kwargs):
+            if "company_tickers" in url:
+                return _make_response(SAMPLE_TICKERS_JSON)
+            return _make_response(submissions_data)
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        result = await sec.get_company_filings(ticker="AAPL")
+        self.assertIn("Apple Inc.", result)
+        self.assertIn("10-K", result)
+        self.assertNotIn("please use the CIK number", result)
+
+    @patch("mcp_govt_api.tools.sec.http_client")
+    async def test_ticker_not_found_returns_error(self, mock_client):
+        mock_client.get = AsyncMock(return_value=_make_response(SAMPLE_TICKERS_JSON))
+
+        result = await sec.get_company_filings(ticker="ZZZZZ")
+        self.assertIn("not found", result)
+        self.assertIn("ZZZZZ", result)
+
+
+class TestSearchCompany(unittest.IsolatedAsyncioTestCase):
+    """Tests for the search_company tool."""
+
+    def setUp(self):
+        sec._ticker_cache = {}
+        sec._ticker_cache_time = 0.0
+
+    async def test_no_args_returns_error(self):
+        result = await sec.search_company()
+        self.assertIn("Error", result)
+
+    @patch("mcp_govt_api.tools.sec.http_client")
+    async def test_search_by_ticker_found(self, mock_client):
+        mock_client.get = AsyncMock(return_value=_make_response(SAMPLE_TICKERS_JSON))
+
+        result = await sec.search_company(ticker="MSFT")
+        self.assertIn("Microsoft Corp", result)
+        self.assertIn("789019", result)
+        self.assertIn("Company Found", result)
+
+    @patch("mcp_govt_api.tools.sec.http_client")
+    async def test_search_by_ticker_not_found(self, mock_client):
+        mock_client.get = AsyncMock(return_value=_make_response(SAMPLE_TICKERS_JSON))
+
+        result = await sec.search_company(ticker="ZZZZZ")
+        self.assertIn("not found", result)
+
+    @patch("mcp_govt_api.tools.sec.http_client")
+    async def test_search_by_name_found(self, mock_client):
+        mock_client.get = AsyncMock(return_value=_make_response(SAMPLE_TICKERS_JSON))
+
+        result = await sec.search_company(name="Apple")
+        self.assertIn("Apple Inc.", result)
+        self.assertIn("320193", result)
+        self.assertIn("AAPL", result)
+
+    @patch("mcp_govt_api.tools.sec.http_client")
+    async def test_search_by_name_case_insensitive(self, mock_client):
+        mock_client.get = AsyncMock(return_value=_make_response(SAMPLE_TICKERS_JSON))
+
+        result = await sec.search_company(name="amazon")
+        self.assertIn("Amazon", result)
+        self.assertIn("AMZN", result)
+
+    @patch("mcp_govt_api.tools.sec.http_client")
+    async def test_search_by_name_not_found(self, mock_client):
+        mock_client.get = AsyncMock(return_value=_make_response(SAMPLE_TICKERS_JSON))
+
+        result = await sec.search_company(name="Nonexistent Corp XYZ")
+        self.assertIn("No results found", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Implements automatic ticker-to-CIK resolution using SEC's company_tickers.json
- Adds in-memory cache with 1-hour TTL for the tickers lookup table
- `get_company_filings` and `search_company` now resolve tickers automatically instead of asking users to manually look up CIK numbers
- 19 new unit tests covering cache, resolution, and both tools

## Test plan
- [x] All 26 tests pass (19 new + 7 existing)
- [x] `python -m compileall src` passes

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)