### PR TITLE
Add BEA regional and national economic accounts tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@
 # Get a free key at https://www.eia.gov/opendata/register.php
 # EIA_API_KEY=your_eia_api_key
 
+# BEA API (required for regional/national economic accounts tools)
+# Get a free key at https://apps.bea.gov/API/signup/
+# BEA_API_KEY=your_bea_api_key
+
 # API Timeout (seconds)
 API_TIMEOUT=30
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
 [![CI](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml/badge.svg)](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml)
-[![77 Tools](https://img.shields.io/badge/tools-77-2563eb.svg?style=flat-square)](#tool-reference)
-[![22 APIs](https://img.shields.io/badge/APIs-22-7c3aed.svg?style=flat-square)](#data-sources)
+[![80 Tools](https://img.shields.io/badge/tools-80-2563eb.svg?style=flat-square)](#tool-reference)
+[![23 APIs](https://img.shields.io/badge/APIs-23-7c3aed.svg?style=flat-square)](#data-sources)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776ab.svg?style=flat-square)](https://python.org)
 [![MCP](https://img.shields.io/badge/protocol-MCP-f97316.svg?style=flat-square)](https://modelcontextprotocol.io)
 
-An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **22 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, disaster management, FDA safety data, national parks, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
+An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **23 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, disaster management, FDA safety data, national parks, open data discovery, cybersecurity, SEC disclosures, Federal Reserve economic indicators, and BEA economic accounts.
 
 Built for practical agent workflows: concise high-level tools, raw query access where it matters, and location-aware inputs that accept city names, ZIP codes, addresses, or raw coordinates.
 
-No API keys required for 14 of 22 sources. Install it, point your MCP client at it, and start querying real civic data.
+No API keys required for 14 of 23 sources. Install it, point your MCP client at it, and start querying real civic data.
 
 [Get Started](#get-started) · [What's New](#whats-new) · [Data Sources](#data-sources) · [Tool Reference](#tool-reference) · [Roadmap](#implementation-roadmap) · [Contributing](CONTRIBUTING.md)
 
@@ -39,7 +39,8 @@ No API keys required for 14 of 22 sources. Install it, point your MCP client at 
         "FRED_API_KEY": "optional",
         "BLS_API_KEY": "optional",
         "NPS_API_KEY": "optional",
-        "EIA_API_KEY": "optional"
+        "EIA_API_KEY": "optional",
+        "BEA_API_KEY": "optional"
       }
     }
   }
@@ -65,6 +66,7 @@ python3 -m mcp_govt_api
 - Added SEC EDGAR tools for filings, submissions, and company facts
 - Added GitHub Actions CI for install, compile, unit test, import, and build validation
 - Added `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `SECURITY.md`
+- Added BEA regional and national economic accounts tools (GDP, income, industry)
 - Added branch protection and required automated checks on `main`
 
 ---
@@ -106,6 +108,7 @@ python3 -m mcp_govt_api
 | [World Bank](https://worldbank.org) | GDP, poverty, unemployment for 200+ countries | -- |
 | [FRED](https://fred.stlouisfed.org) | Federal Reserve economic data: GDP, inflation, employment, interest rates | Required |
 | [BLS](https://www.bls.gov) | CPI, unemployment, employment, labor statistics | Optional |
+| [BEA](https://www.bea.gov) | Regional GDP, personal income, GDP by industry | Required |
 
 ### Energy
 
@@ -183,6 +186,9 @@ python3 -m mcp_govt_api
 "What are the current gasoline prices?"
 "Show me electricity data for California"
 "What energy data categories does the EIA provide?"
+"What's California's GDP from BEA?"
+"Show me GDP by industry for 2022"
+"What datasets does the BEA offer?"
 ```
 
 ---
@@ -429,6 +435,17 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 </details>
 
 <details>
+<summary><strong>Economics (BEA)</strong> — 3 tools</summary>
+
+| Tool | Description |
+|------|-------------|
+| `get_bea_regional_data` | Regional GDP, income, and employment data by state |
+| `get_bea_gdp_by_industry` | GDP breakdown by industry sector |
+| `search_bea_datasets` | List available BEA datasets and tables |
+
+</details>
+
+<details>
 <summary><strong>NASA</strong> — 4 tools</summary>
 
 | Tool | Description |
@@ -466,6 +483,7 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 | `BLS_API_KEY` | Higher rate limits for BLS (25 to 500 queries/day) | *(works without key)* |
 | `NPS_API_KEY` | Enables National Park Service tools | *(disabled)* |
 | `EIA_API_KEY` | Enables EIA energy market tools | *(disabled)* |
+| `BEA_API_KEY` | Enables BEA economic accounts tools | *(disabled)* |
 | `API_TIMEOUT` | Request timeout in seconds | `30` |
 
 On startup the server prints which APIs are available:
@@ -480,6 +498,7 @@ API Availability:
   ✓ BLS                   ✓ FEMA
   ✗ OpenWeather (key not set)
   ✗ EIA (key not set)
+  ✗ BEA (key not set)
 ```
 
 ---

--- a/src/mcp_govt_api/server.py
+++ b/src/mcp_govt_api/server.py
@@ -30,6 +30,7 @@ mcp = FastMCP(
 - NOAA CO-OPS (tide predictions, observed water levels, coastal stations)
 - NPS (national parks, park alerts, and park details)
 - EIA (electricity data, petroleum prices, energy market overview; requires API key)
+- BEA (regional GDP, personal income, GDP by industry; requires API key)
 """,
 )
 
@@ -42,6 +43,7 @@ def main():
 
 # Import tools to register them
 from mcp_govt_api.tools import (  # noqa: E402
+    bea,  # noqa: F401
     bls,  # noqa: F401
     cdc,  # noqa: F401
     census,  # noqa: F401

--- a/src/mcp_govt_api/tools/bea.py
+++ b/src/mcp_govt_api/tools/bea.py
@@ -1,0 +1,254 @@
+from mcp_govt_api.server import mcp
+from mcp_govt_api.utils.config import config
+from mcp_govt_api.utils.http import fetch_json
+
+
+BEA_BASE = "https://apps.bea.gov/api/data/"
+
+
+def _require_key() -> str:
+    """Return the BEA API key or raise an error."""
+    if not config.bea_api_key:
+        raise ValueError(
+            "BEA_API_KEY environment variable is not set. "
+            "Get a free key at https://apps.bea.gov/API/signup/"
+        )
+    return config.bea_api_key
+
+
+@mcp.tool()
+async def get_bea_regional_data(
+    table: str = "CAGDP1",
+    state: str = "",
+    year: str = "",
+    limit: int = 10,
+) -> str:
+    """Get regional economic data (GDP, income, employment) by state from the BEA.
+
+    Args:
+        table: BEA table name. Common tables:
+               'CAGDP1' (GDP summary), 'CAINC1' (personal income),
+               'CAINC4' (income and employment), 'CAGDP9' (real GDP).
+        state: Two-letter state code (e.g., 'CA', 'TX') or FIPS code.
+               Leave empty for all states.
+        year: Year(s) for data (e.g., '2022' or '2020,2021,2022').
+              Leave empty for the most recent year.
+        limit: Maximum number of records to return (default 10).
+
+    Returns:
+        Regional economic data for the specified state(s) and table.
+    """
+    try:
+        api_key = _require_key()
+    except ValueError as exc:
+        return str(exc)
+
+    # Map state abbreviations to BEA GeoFips codes
+    state_fips = {
+        "AL": "01000", "AK": "02000", "AZ": "04000", "AR": "05000",
+        "CA": "06000", "CO": "08000", "CT": "09000", "DE": "10000",
+        "FL": "12000", "GA": "13000", "HI": "15000", "ID": "16000",
+        "IL": "17000", "IN": "18000", "IA": "19000", "KS": "20000",
+        "KY": "21000", "LA": "22000", "ME": "23000", "MD": "24000",
+        "MA": "25000", "MI": "26000", "MN": "27000", "MS": "28000",
+        "MO": "29000", "MT": "30000", "NE": "31000", "NV": "32000",
+        "NH": "33000", "NJ": "34000", "NM": "35000", "NY": "36000",
+        "NC": "37000", "ND": "38000", "OH": "39000", "OK": "40000",
+        "OR": "41000", "PA": "42000", "RI": "44000", "SC": "45000",
+        "SD": "46000", "TN": "47000", "TX": "48000", "UT": "49000",
+        "VT": "50000", "VA": "51000", "WA": "53000", "WV": "54000",
+        "WI": "55000", "WY": "56000", "DC": "11000",
+    }
+
+    geo_fips = "STATE"
+    if state:
+        upper = state.upper()
+        if upper in state_fips:
+            geo_fips = state_fips[upper]
+        else:
+            geo_fips = upper
+
+    params: dict = {
+        "UserID": api_key,
+        "method": "GetData",
+        "DataSetName": "Regional",
+        "TableName": table,
+        "GeoFips": geo_fips,
+        "ResultFormat": "JSON",
+    }
+    if year:
+        params["Year"] = year
+    else:
+        params["Year"] = "LAST5"
+
+    try:
+        data = await fetch_json(BEA_BASE, params=params)
+    except Exception as exc:
+        return f"Error fetching BEA regional data: {exc}"
+
+    results = data.get("BEAAPI", {}).get("Results", {})
+
+    # Handle API-level errors
+    error = results.get("Error")
+    if error:
+        msg = error.get("APIErrorDescription", str(error))
+        return f"BEA API error: {msg}"
+
+    records = results.get("Data", [])
+    if not records:
+        label = state.upper() if state else "all states"
+        return f"No BEA regional data found for {label} (table={table})."
+
+    # Limit records
+    records = records[:limit]
+
+    label = state.upper() if state else "All States"
+    lines = [f"**BEA Regional Data — {label}** (Table: {table})\n"]
+
+    for rec in records:
+        geo = rec.get("GeoName", "N/A")
+        yr = rec.get("TimePeriod", "N/A")
+        value = rec.get("DataValue", "N/A")
+        desc = rec.get("Description", "")
+        unit = rec.get("UNIT_MULT_DESC", "")
+
+        parts = [f"  - **{geo}** ({yr})"]
+        if desc:
+            parts.append(desc)
+        parts.append(str(value))
+        if unit:
+            parts.append(f"[{unit}]")
+
+        lines.append(" | ".join(parts))
+
+    note_text = results.get("NoteText", "")
+    if note_text:
+        lines.append(f"\n_{note_text[:200]}_")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_bea_gdp_by_industry(
+    year: str = "",
+    industry: str = "",
+    limit: int = 10,
+) -> str:
+    """Get GDP data broken down by industry sector from the BEA.
+
+    Args:
+        year: Year for data (e.g., '2022'). Leave empty for the most recent year.
+        industry: Industry code (e.g., '11' for Agriculture, '54' for Professional Services).
+                  Leave empty for all industries.
+        limit: Maximum number of records to return (default 10).
+
+    Returns:
+        GDP by industry data showing value added by sector.
+    """
+    try:
+        api_key = _require_key()
+    except ValueError as exc:
+        return str(exc)
+
+    params: dict = {
+        "UserID": api_key,
+        "method": "GetData",
+        "DataSetName": "GDPbyIndustry",
+        "TableID": "1",
+        "Frequency": "A",
+        "ResultFormat": "JSON",
+    }
+    if year:
+        params["Year"] = year
+    else:
+        params["Year"] = "LAST5"
+
+    if industry:
+        params["Industry"] = industry
+    else:
+        params["Industry"] = "ALL"
+
+    try:
+        data = await fetch_json(BEA_BASE, params=params)
+    except Exception as exc:
+        return f"Error fetching BEA GDP by industry: {exc}"
+
+    results = data.get("BEAAPI", {}).get("Results", {})
+
+    error = results.get("Error")
+    if error:
+        msg = error.get("APIErrorDescription", str(error))
+        return f"BEA API error: {msg}"
+
+    records = results.get("Data", [])
+    if not records:
+        label = f"industry {industry}" if industry else "all industries"
+        return f"No BEA GDP by industry data found for {label}."
+
+    records = records[:limit]
+
+    label = f"Industry {industry}" if industry else "All Industries"
+    lines = [f"**BEA GDP by Industry — {label}**\n"]
+
+    for rec in records:
+        ind_desc = rec.get("IndustrYDescription", rec.get("IndustryDescription", "N/A"))
+        yr = rec.get("Year", "N/A")
+        value = rec.get("DataValue", "N/A")
+        freq = rec.get("FreqDesc", "")
+
+        parts = [f"  - **{ind_desc}** ({yr})"]
+        parts.append(str(value))
+        if freq:
+            parts.append(f"[{freq}]")
+
+        lines.append(" | ".join(parts))
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def search_bea_datasets() -> str:
+    """List available BEA datasets and their descriptions.
+
+    Returns:
+        A list of all available BEA API datasets with descriptions.
+    """
+    try:
+        api_key = _require_key()
+    except ValueError as exc:
+        return str(exc)
+
+    params = {
+        "UserID": api_key,
+        "method": "GetDataSetList",
+        "ResultFormat": "JSON",
+    }
+
+    try:
+        data = await fetch_json(BEA_BASE, params=params)
+    except Exception as exc:
+        return f"Error fetching BEA datasets: {exc}"
+
+    results = data.get("BEAAPI", {}).get("Results", {})
+
+    error = results.get("Error")
+    if error:
+        msg = error.get("APIErrorDescription", str(error))
+        return f"BEA API error: {msg}"
+
+    datasets = results.get("Dataset", [])
+    if not datasets:
+        return "No BEA datasets found."
+
+    lines = ["**Available BEA Datasets**\n"]
+
+    for ds in datasets:
+        name = ds.get("DatasetName", "N/A")
+        desc = ds.get("DatasetDescription", "")
+        lines.append(f"  - **{name}**: {desc}")
+
+    lines.append("\n_Common Regional tables: CAGDP1 (GDP summary), "
+                 "CAINC1 (personal income), CAINC4 (income & employment), "
+                 "CAGDP9 (real GDP by state)._")
+
+    return "\n".join(lines)

--- a/src/mcp_govt_api/utils/config.py
+++ b/src/mcp_govt_api/utils/config.py
@@ -12,6 +12,7 @@ class Config:
     bls_api_key: str | None = None
     nps_api_key: str | None = None
     eia_api_key: str | None = None
+    bea_api_key: str | None = None
     timeout: int = 30
 
     def __post_init__(self):
@@ -21,6 +22,7 @@ class Config:
         self.bls_api_key = os.environ.get("BLS_API_KEY")
         self.nps_api_key = os.environ.get("NPS_API_KEY")
         self.eia_api_key = os.environ.get("EIA_API_KEY")
+        self.bea_api_key = os.environ.get("BEA_API_KEY")
         self.timeout = int(os.environ.get("API_TIMEOUT", "30"))
 
     @property
@@ -46,6 +48,10 @@ class Config:
     @property
     def has_eia(self) -> bool:
         return bool(self.eia_api_key)
+
+    @property
+    def has_bea(self) -> bool:
+        return bool(self.bea_api_key)
 
     def get_availability_summary(self) -> str:
         """Return a summary of API availability."""
@@ -92,6 +98,10 @@ class Config:
             lines.append("  ✓ EIA (API key configured)")
         else:
             lines.append("  ✗ EIA (EIA_API_KEY not set)")
+        if self.has_bea:
+            lines.append("  ✓ BEA (API key configured)")
+        else:
+            lines.append("  ✗ BEA (BEA_API_KEY not set)")
         if self.has_nasa_key:
             lines.append("  ✓ NASA FIRMS (using NASA API key)")
         else:

--- a/tests/test_bea.py
+++ b/tests/test_bea.py
@@ -1,0 +1,234 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from mcp_govt_api.tools.bea import (
+    get_bea_gdp_by_industry,
+    get_bea_regional_data,
+    search_bea_datasets,
+)
+
+
+class BeaToolTests(unittest.IsolatedAsyncioTestCase):
+    @patch("mcp_govt_api.tools.bea.config")
+    @patch(
+        "mcp_govt_api.tools.bea.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_get_bea_regional_data_returns_results(self, mock_fetch, mock_config):
+        mock_config.bea_api_key = "test-key"
+        mock_fetch.return_value = {
+            "BEAAPI": {
+                "Results": {
+                    "Data": [
+                        {
+                            "GeoName": "California",
+                            "TimePeriod": "2022",
+                            "DataValue": "3,598,103",
+                            "Description": "Real GDP (millions of chained 2017 dollars)",
+                            "UNIT_MULT_DESC": "Millions of dollars",
+                        }
+                    ]
+                }
+            }
+        }
+
+        result = await get_bea_regional_data(table="CAGDP1", state="CA", year="2022")
+
+        self.assertIn("California", result)
+        self.assertIn("2022", result)
+        self.assertIn("3,598,103", result)
+        self.assertIn("BEA Regional Data", result)
+        mock_fetch.assert_awaited_once()
+        call_args = mock_fetch.call_args
+        self.assertEqual(call_args.kwargs["params"]["TableName"], "CAGDP1")
+        self.assertEqual(call_args.kwargs["params"]["GeoFips"], "06000")
+
+    @patch("mcp_govt_api.tools.bea.config")
+    @patch(
+        "mcp_govt_api.tools.bea.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_get_bea_regional_data_all_states(self, mock_fetch, mock_config):
+        mock_config.bea_api_key = "test-key"
+        mock_fetch.return_value = {
+            "BEAAPI": {
+                "Results": {
+                    "Data": [
+                        {
+                            "GeoName": "United States",
+                            "TimePeriod": "2022",
+                            "DataValue": "25,462,700",
+                            "Description": "GDP",
+                        }
+                    ]
+                }
+            }
+        }
+
+        result = await get_bea_regional_data()
+
+        self.assertIn("All States", result)
+        self.assertIn("United States", result)
+        mock_fetch.assert_awaited_once()
+        call_args = mock_fetch.call_args
+        self.assertEqual(call_args.kwargs["params"]["GeoFips"], "STATE")
+
+    @patch("mcp_govt_api.tools.bea.config")
+    @patch(
+        "mcp_govt_api.tools.bea.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_get_bea_regional_data_no_results(self, mock_fetch, mock_config):
+        mock_config.bea_api_key = "test-key"
+        mock_fetch.return_value = {"BEAAPI": {"Results": {"Data": []}}}
+
+        result = await get_bea_regional_data(state="ZZ")
+
+        self.assertIn("No BEA regional data found", result)
+
+    @patch("mcp_govt_api.tools.bea.config")
+    @patch(
+        "mcp_govt_api.tools.bea.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_get_bea_regional_data_api_error(self, mock_fetch, mock_config):
+        mock_config.bea_api_key = "test-key"
+        mock_fetch.return_value = {
+            "BEAAPI": {
+                "Results": {
+                    "Error": {
+                        "APIErrorDescription": "Invalid table name"
+                    }
+                }
+            }
+        }
+
+        result = await get_bea_regional_data(table="BADTABLE")
+
+        self.assertIn("BEA API error", result)
+        self.assertIn("Invalid table name", result)
+
+    @patch("mcp_govt_api.tools.bea.config")
+    @patch(
+        "mcp_govt_api.tools.bea.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_get_bea_gdp_by_industry_returns_results(self, mock_fetch, mock_config):
+        mock_config.bea_api_key = "test-key"
+        mock_fetch.return_value = {
+            "BEAAPI": {
+                "Results": {
+                    "Data": [
+                        {
+                            "IndustryDescription": "All industries",
+                            "Year": "2022",
+                            "DataValue": "25,462.7",
+                            "FreqDesc": "Annual",
+                        }
+                    ]
+                }
+            }
+        }
+
+        result = await get_bea_gdp_by_industry(year="2022")
+
+        self.assertIn("All industries", result)
+        self.assertIn("2022", result)
+        self.assertIn("25,462.7", result)
+        self.assertIn("BEA GDP by Industry", result)
+        mock_fetch.assert_awaited_once()
+        call_args = mock_fetch.call_args
+        self.assertEqual(call_args.kwargs["params"]["DataSetName"], "GDPbyIndustry")
+
+    @patch("mcp_govt_api.tools.bea.config")
+    @patch(
+        "mcp_govt_api.tools.bea.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_get_bea_gdp_by_industry_no_results(self, mock_fetch, mock_config):
+        mock_config.bea_api_key = "test-key"
+        mock_fetch.return_value = {"BEAAPI": {"Results": {"Data": []}}}
+
+        result = await get_bea_gdp_by_industry(industry="99")
+
+        self.assertIn("No BEA GDP by industry data found", result)
+
+    @patch("mcp_govt_api.tools.bea.config")
+    @patch(
+        "mcp_govt_api.tools.bea.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_search_bea_datasets_returns_results(self, mock_fetch, mock_config):
+        mock_config.bea_api_key = "test-key"
+        mock_fetch.return_value = {
+            "BEAAPI": {
+                "Results": {
+                    "Dataset": [
+                        {
+                            "DatasetName": "Regional",
+                            "DatasetDescription": "Regional economic data",
+                        },
+                        {
+                            "DatasetName": "NIPA",
+                            "DatasetDescription": "National Income and Product Accounts",
+                        },
+                    ]
+                }
+            }
+        }
+
+        result = await search_bea_datasets()
+
+        self.assertIn("Available BEA Datasets", result)
+        self.assertIn("Regional", result)
+        self.assertIn("NIPA", result)
+        self.assertIn("National Income and Product Accounts", result)
+        mock_fetch.assert_awaited_once()
+
+    @patch("mcp_govt_api.tools.bea.config")
+    @patch(
+        "mcp_govt_api.tools.bea.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_search_bea_datasets_no_results(self, mock_fetch, mock_config):
+        mock_config.bea_api_key = "test-key"
+        mock_fetch.return_value = {"BEAAPI": {"Results": {"Dataset": []}}}
+
+        result = await search_bea_datasets()
+
+        self.assertIn("No BEA datasets found", result)
+
+    @patch("mcp_govt_api.tools.bea.config")
+    async def test_missing_api_key_returns_error(self, mock_config):
+        mock_config.bea_api_key = None
+
+        result = await get_bea_regional_data()
+        self.assertIn("BEA_API_KEY", result)
+
+        result = await get_bea_gdp_by_industry()
+        self.assertIn("BEA_API_KEY", result)
+
+        result = await search_bea_datasets()
+        self.assertIn("BEA_API_KEY", result)
+
+    @patch("mcp_govt_api.tools.bea.config")
+    @patch(
+        "mcp_govt_api.tools.bea.fetch_json",
+        new_callable=AsyncMock,
+    )
+    async def test_fetch_error_handled_gracefully(self, mock_fetch, mock_config):
+        mock_config.bea_api_key = "test-key"
+        mock_fetch.side_effect = Exception("Connection timeout")
+
+        result = await get_bea_regional_data()
+        self.assertIn("Error fetching BEA regional data", result)
+
+        result = await get_bea_gdp_by_industry()
+        self.assertIn("Error fetching BEA GDP by industry", result)
+
+        result = await search_bea_datasets()
+        self.assertIn("Error fetching BEA datasets", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 3 new tools: `get_bea_regional_data`, `get_bea_gdp_by_industry`, `search_bea_datasets`
- Uses BEA API with optional API key; 9 tests
Closes #83
🤖 Generated with [Claude Code](https://claude.com/claude-code)