### PR TITLE
Add BTS freight and transportation performance tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
 [![CI](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml/badge.svg)](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml)
-[![77 Tools](https://img.shields.io/badge/tools-77-2563eb.svg?style=flat-square)](#tool-reference)
-[![22 APIs](https://img.shields.io/badge/APIs-22-7c3aed.svg?style=flat-square)](#data-sources)
+[![80 Tools](https://img.shields.io/badge/tools-80-2563eb.svg?style=flat-square)](#tool-reference)
+[![23 APIs](https://img.shields.io/badge/APIs-23-7c3aed.svg?style=flat-square)](#data-sources)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776ab.svg?style=flat-square)](https://python.org)
 [![MCP](https://img.shields.io/badge/protocol-MCP-f97316.svg?style=flat-square)](https://modelcontextprotocol.io)
 
-An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **22 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, disaster management, FDA safety data, national parks, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
+An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **23 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, disaster management, FDA safety data, national parks, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
 
 Built for practical agent workflows: concise high-level tools, raw query access where it matters, and location-aware inputs that accept city names, ZIP codes, addresses, or raw coordinates.
 
@@ -113,6 +113,12 @@ python3 -m mcp_govt_api
 |--------|---------------|-----|
 | [EIA](https://www.eia.gov/opendata/) | Electricity, petroleum, natural gas, coal, and energy market data | Required |
 
+### Transportation
+
+| Source | What It Covers | Key |
+|--------|---------------|-----|
+| [BTS](https://data.bts.gov) | Airline on-time performance, border crossing data, transportation datasets | -- |
+
 ### Finance & Securities
 
 | Source | What It Covers | Key |
@@ -183,6 +189,9 @@ python3 -m mcp_govt_api
 "What are the current gasoline prices?"
 "Show me electricity data for California"
 "What energy data categories does the EIA provide?"
+"Show me airline on-time stats for American Airlines"
+"What's the border crossing data for El Paso?"
+"Search BTS datasets about freight"
 ```
 
 ---
@@ -369,6 +378,17 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 | `get_electricity_data` | Retail electricity sales, prices, and revenue by state |
 | `get_petroleum_prices` | Gasoline, diesel, and heating oil price data |
 | `get_energy_overview` | Browse available EIA data categories and routes |
+
+</details>
+
+<details>
+<summary><strong>Transportation (BTS)</strong> — 3 tools</summary>
+
+| Tool | Description |
+|------|-------------|
+| `get_airline_ontime_stats` | Airline on-time performance, delays, and cancellations |
+| `get_border_crossing_data` | US-Canada and US-Mexico border crossing entry data |
+| `search_bts_datasets` | Search BTS open datasets on data.bts.gov |
 
 </details>
 

--- a/src/mcp_govt_api/server.py
+++ b/src/mcp_govt_api/server.py
@@ -30,6 +30,7 @@ mcp = FastMCP(
 - NOAA CO-OPS (tide predictions, observed water levels, coastal stations)
 - NPS (national parks, park alerts, and park details)
 - EIA (electricity data, petroleum prices, energy market overview; requires API key)
+- BTS (airline on-time performance, border crossing data, transportation datasets)
 """,
 )
 
@@ -43,6 +44,7 @@ def main():
 # Import tools to register them
 from mcp_govt_api.tools import (  # noqa: E402
     bls,  # noqa: F401
+    bts,  # noqa: F401
     cdc,  # noqa: F401
     census,  # noqa: F401
     cisa,  # noqa: F401

--- a/src/mcp_govt_api/tools/bts.py
+++ b/src/mcp_govt_api/tools/bts.py
@@ -1,0 +1,250 @@
+from mcp_govt_api.server import mcp
+from mcp_govt_api.utils.http import fetch_json
+from mcp_govt_api.utils.validation import validate_limit
+
+BTS_BASE = "https://data.bts.gov/resource"
+AIRLINE_ONTIME_DATASET = "2wkt-wbq2"
+BORDER_CROSSING_DATASET = "keg4-3bc2"
+BTS_DISCOVERY_URL = "https://data.bts.gov/api/catalog/v1"
+
+
+@mcp.tool()
+async def get_airline_ontime_stats(
+    carrier: str = "",
+    airport: str = "",
+    limit: int = 20,
+) -> str:
+    """Get airline on-time performance statistics from BTS.
+
+    Returns data on flight delays, cancellations, and on-time arrival
+    performance for US airlines. Data sourced from the Bureau of
+    Transportation Statistics via data.bts.gov.
+
+    Args:
+        carrier: Filter by airline carrier code (e.g., 'AA', 'UA', 'DL', 'WN')
+        airport: Filter by airport code (e.g., 'ATL', 'ORD', 'LAX', 'JFK')
+        limit: Maximum number of records to return (default: 20, max: 100)
+
+    Returns:
+        Airline on-time performance records including carrier, airport,
+        arrival delays, departure delays, and cancellation information.
+    """
+    limit = validate_limit(limit, max_val=100, default=20)
+
+    url = f"{BTS_BASE}/{AIRLINE_ONTIME_DATASET}.json"
+    params: dict[str, str | int] = {
+        "$limit": limit,
+        "$order": ":id",
+    }
+
+    where_clauses: list[str] = []
+    if carrier:
+        where_clauses.append(f"upper(carrier) = '{carrier.strip().upper()}'")
+    if airport:
+        airport_upper = airport.strip().upper()
+        where_clauses.append(
+            f"(upper(origin) = '{airport_upper}' OR upper(dest) = '{airport_upper}')"
+        )
+
+    if where_clauses:
+        params["$where"] = " AND ".join(where_clauses)
+
+    try:
+        data = await fetch_json(url, params=params)
+    except Exception as e:
+        return f"Error fetching airline on-time data: {e}"
+
+    if not data:
+        filters = []
+        if carrier:
+            filters.append(f"carrier '{carrier}'")
+        if airport:
+            filters.append(f"airport '{airport}'")
+        filter_str = " and ".join(filters) if filters else "the given criteria"
+        return f"No airline on-time performance data found for {filter_str}."
+
+    lines = [f"Airline On-Time Performance ({len(data)} records):\n"]
+
+    for record in data:
+        carrier_name = record.get("carrier_name") or record.get("carrier", "N/A")
+        carrier_code = record.get("carrier", "N/A")
+        origin = record.get("origin", "N/A")
+        dest = record.get("dest", "N/A")
+        arr_delay = record.get("arr_delay", "N/A")
+        dep_delay = record.get("dep_delay", "N/A")
+        cancelled = record.get("cancelled", "N/A")
+        flights = record.get("flights", record.get("fl_date", "N/A"))
+
+        lines.append(f"**{carrier_name}** ({carrier_code})")
+        lines.append(f"  Route: {origin} -> {dest}")
+        if arr_delay != "N/A":
+            lines.append(f"  Arrival Delay: {arr_delay} min")
+        if dep_delay != "N/A":
+            lines.append(f"  Departure Delay: {dep_delay} min")
+        if cancelled != "N/A":
+            lines.append(f"  Cancelled: {cancelled}")
+        if flights != "N/A":
+            lines.append(f"  Flights/Date: {flights}")
+        lines.append("")
+
+    lines.append("_Source: Bureau of Transportation Statistics (data.bts.gov)_")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_border_crossing_data(
+    port: str = "",
+    state: str = "",
+    measure: str = "",
+    limit: int = 20,
+) -> str:
+    """Get border crossing and entry data from BTS.
+
+    Returns data on the number of incoming crossings at US-Canada and
+    US-Mexico border ports of entry. Includes pedestrians, personal
+    vehicles, trucks, trains, and more.
+
+    Args:
+        port: Filter by port name (e.g., 'El Paso', 'Detroit', 'Buffalo')
+        state: Filter by US state (e.g., 'Texas', 'California', 'New York')
+        measure: Filter by crossing type (e.g., 'Trucks', 'Personal Vehicles',
+                 'Pedestrians', 'Train Passengers')
+        limit: Maximum number of records to return (default: 20, max: 100)
+
+    Returns:
+        Border crossing records including port name, state, border,
+        crossing measure, and value.
+    """
+    limit = validate_limit(limit, max_val=100, default=20)
+
+    url = f"{BTS_BASE}/{BORDER_CROSSING_DATASET}.json"
+    params: dict[str, str | int] = {
+        "$limit": limit,
+        "$order": "date DESC",
+    }
+
+    where_clauses: list[str] = []
+    if port:
+        where_clauses.append(f"upper(port_name) like '%{port.strip().upper()}%'")
+    if state:
+        where_clauses.append(f"upper(state) like '%{state.strip().upper()}%'")
+    if measure:
+        where_clauses.append(f"upper(measure) like '%{measure.strip().upper()}%'")
+
+    if where_clauses:
+        params["$where"] = " AND ".join(where_clauses)
+
+    try:
+        data = await fetch_json(url, params=params)
+    except Exception as e:
+        return f"Error fetching border crossing data: {e}"
+
+    if not data:
+        filters = []
+        if port:
+            filters.append(f"port '{port}'")
+        if state:
+            filters.append(f"state '{state}'")
+        if measure:
+            filters.append(f"measure '{measure}'")
+        filter_str = " and ".join(filters) if filters else "the given criteria"
+        return f"No border crossing data found for {filter_str}."
+
+    lines = [f"Border Crossing Data ({len(data)} records):\n"]
+
+    for record in data:
+        port_name = record.get("port_name", "N/A")
+        rec_state = record.get("state", "N/A")
+        border = record.get("border", "N/A")
+        date = record.get("date", "N/A")
+        rec_measure = record.get("measure", "N/A")
+        value = record.get("value", "N/A")
+
+        # Format date if it's a full timestamp
+        if isinstance(date, str) and "T" in date:
+            date = date.split("T")[0]
+
+        lines.append(f"**{port_name}**, {rec_state}")
+        lines.append(f"  Border: {border}")
+        lines.append(f"  Date: {date}")
+        lines.append(f"  Measure: {rec_measure}")
+        lines.append(f"  Value: {value}")
+        lines.append("")
+
+    lines.append("_Source: Bureau of Transportation Statistics (data.bts.gov)_")
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def search_bts_datasets(
+    query: str = "",
+    limit: int = 10,
+) -> str:
+    """Search BTS open datasets on data.bts.gov.
+
+    Browse and discover datasets published by the Bureau of Transportation
+    Statistics, including airline, freight, border crossing, and other
+    transportation data.
+
+    Args:
+        query: Search term (e.g., 'airline', 'freight', 'border', 'traffic')
+        limit: Maximum number of datasets to return (default: 10, max: 50)
+
+    Returns:
+        List of matching BTS datasets with names, descriptions, and links.
+    """
+    limit = validate_limit(limit, max_val=50, default=10)
+
+    params: dict[str, str | int] = {
+        "limit": limit,
+    }
+    if query:
+        params["q"] = query.strip()
+
+    try:
+        data = await fetch_json(BTS_DISCOVERY_URL, params=params)
+    except Exception as e:
+        return f"Error searching BTS datasets: {e}"
+
+    results = data.get("results", data) if isinstance(data, dict) else data
+
+    if not results:
+        return f"No BTS datasets found matching '{query}'." if query else "No BTS datasets found."
+
+    # Handle both list and dict response formats
+    if isinstance(results, dict):
+        results = results.get("results", [])
+
+    if not isinstance(results, list):
+        return "Unexpected response format from BTS catalog API."
+
+    lines = [f"BTS Datasets ({len(results)} results):\n"]
+
+    for dataset in results[:limit]:
+        resource = dataset.get("resource", dataset)
+        name = resource.get("name", dataset.get("name", "Untitled"))
+        description = resource.get("description", dataset.get("description", ""))
+        dataset_id = resource.get("id", dataset.get("id", ""))
+        updated = resource.get("updatedAt", dataset.get("updatedAt", ""))
+        page_url = dataset.get("permalink", dataset.get("link", ""))
+
+        if isinstance(description, str) and len(description) > 200:
+            description = description[:200] + "..."
+
+        # Format updated date
+        if isinstance(updated, str) and "T" in updated:
+            updated = updated.split("T")[0]
+
+        lines.append(f"**{name}**")
+        if dataset_id:
+            lines.append(f"  ID: {dataset_id}")
+        if description:
+            lines.append(f"  Description: {description}")
+        if updated:
+            lines.append(f"  Last Updated: {updated}")
+        if page_url:
+            lines.append(f"  Link: {page_url}")
+        lines.append("")
+
+    lines.append("_Source: Bureau of Transportation Statistics (data.bts.gov)_")
+    return "\n".join(lines)

--- a/tests/test_bts.py
+++ b/tests/test_bts.py
@@ -1,0 +1,212 @@
+"""Tests for BTS transportation tools."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from mcp_govt_api.tools.bts import (
+    get_airline_ontime_stats,
+    get_border_crossing_data,
+    search_bts_datasets,
+)
+
+
+class TestGetAirlineOntimeStats(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_formatted_results(self):
+        mock_data = [
+            {
+                "carrier": "AA",
+                "carrier_name": "American Airlines",
+                "origin": "ORD",
+                "dest": "LAX",
+                "arr_delay": "12",
+                "dep_delay": "5",
+                "cancelled": "0.00",
+                "flights": "150",
+            },
+            {
+                "carrier": "UA",
+                "carrier_name": "United Airlines",
+                "origin": "SFO",
+                "dest": "JFK",
+                "arr_delay": "-3",
+                "dep_delay": "0",
+                "cancelled": "0.01",
+                "flights": "200",
+            },
+        ]
+
+        with patch(
+            "mcp_govt_api.tools.bts.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await get_airline_ontime_stats(limit=10)
+
+        self.assertIn("Airline On-Time Performance", result)
+        self.assertIn("American Airlines", result)
+        self.assertIn("United Airlines", result)
+        self.assertIn("ORD -> LAX", result)
+        self.assertIn("Arrival Delay: 12 min", result)
+
+    async def test_carrier_filter_passed_to_params(self):
+        with patch(
+            "mcp_govt_api.tools.bts.fetch_json",
+            new=AsyncMock(return_value=[]),
+        ) as mock_fetch:
+            result = await get_airline_ontime_stats(carrier="DL")
+
+        call_args = mock_fetch.call_args
+        params = call_args[1].get("params") or call_args[0][1]
+        self.assertIn("$where", params)
+        self.assertIn("DL", params["$where"])
+        self.assertIn("No airline on-time performance data found", result)
+
+    async def test_airport_filter_passed_to_params(self):
+        with patch(
+            "mcp_govt_api.tools.bts.fetch_json",
+            new=AsyncMock(return_value=[]),
+        ) as mock_fetch:
+            result = await get_airline_ontime_stats(airport="ATL")
+
+        call_args = mock_fetch.call_args
+        params = call_args[1].get("params") or call_args[0][1]
+        self.assertIn("$where", params)
+        self.assertIn("ATL", params["$where"])
+
+    async def test_handles_api_error(self):
+        with patch(
+            "mcp_govt_api.tools.bts.fetch_json",
+            new=AsyncMock(side_effect=Exception("timeout")),
+        ):
+            result = await get_airline_ontime_stats()
+
+        self.assertIn("Error fetching airline on-time data", result)
+
+
+class TestGetBorderCrossingData(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_formatted_results(self):
+        mock_data = [
+            {
+                "port_name": "El Paso",
+                "state": "Texas",
+                "border": "US-Mexico Border",
+                "date": "2024-01-01T00:00:00.000",
+                "measure": "Personal Vehicles",
+                "value": "125000",
+            },
+        ]
+
+        with patch(
+            "mcp_govt_api.tools.bts.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await get_border_crossing_data(limit=10)
+
+        self.assertIn("Border Crossing Data", result)
+        self.assertIn("El Paso", result)
+        self.assertIn("Texas", result)
+        self.assertIn("US-Mexico Border", result)
+        self.assertIn("Personal Vehicles", result)
+        self.assertIn("2024-01-01", result)
+
+    async def test_port_filter_passed_to_params(self):
+        with patch(
+            "mcp_govt_api.tools.bts.fetch_json",
+            new=AsyncMock(return_value=[]),
+        ) as mock_fetch:
+            await get_border_crossing_data(port="Detroit")
+
+        call_args = mock_fetch.call_args
+        params = call_args[1].get("params") or call_args[0][1]
+        self.assertIn("$where", params)
+        self.assertIn("DETROIT", params["$where"])
+
+    async def test_state_filter_passed_to_params(self):
+        with patch(
+            "mcp_govt_api.tools.bts.fetch_json",
+            new=AsyncMock(return_value=[]),
+        ) as mock_fetch:
+            await get_border_crossing_data(state="Texas")
+
+        call_args = mock_fetch.call_args
+        params = call_args[1].get("params") or call_args[0][1]
+        self.assertIn("$where", params)
+        self.assertIn("TEXAS", params["$where"])
+
+    async def test_handles_api_error(self):
+        with patch(
+            "mcp_govt_api.tools.bts.fetch_json",
+            new=AsyncMock(side_effect=Exception("connection refused")),
+        ):
+            result = await get_border_crossing_data()
+
+        self.assertIn("Error fetching border crossing data", result)
+
+    async def test_empty_results(self):
+        with patch(
+            "mcp_govt_api.tools.bts.fetch_json",
+            new=AsyncMock(return_value=[]),
+        ):
+            result = await get_border_crossing_data(port="Nonexistent")
+
+        self.assertIn("No border crossing data found", result)
+
+
+class TestSearchBtsDatasets(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_formatted_results(self):
+        mock_data = {
+            "results": [
+                {
+                    "resource": {
+                        "name": "Airline On-Time Performance",
+                        "id": "2wkt-wbq2",
+                        "description": "Flight delay and cancellation data",
+                        "updatedAt": "2024-06-01T00:00:00.000Z",
+                    },
+                    "permalink": "https://data.bts.gov/d/2wkt-wbq2",
+                },
+            ]
+        }
+
+        with patch(
+            "mcp_govt_api.tools.bts.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await search_bts_datasets(query="airline")
+
+        self.assertIn("BTS Datasets", result)
+        self.assertIn("Airline On-Time Performance", result)
+        self.assertIn("2wkt-wbq2", result)
+        self.assertIn("Flight delay and cancellation data", result)
+
+    async def test_empty_results(self):
+        with patch(
+            "mcp_govt_api.tools.bts.fetch_json",
+            new=AsyncMock(return_value={"results": []}),
+        ):
+            result = await search_bts_datasets(query="nonexistent")
+
+        self.assertIn("No BTS datasets found", result)
+
+    async def test_handles_api_error(self):
+        with patch(
+            "mcp_govt_api.tools.bts.fetch_json",
+            new=AsyncMock(side_effect=Exception("server error")),
+        ):
+            result = await search_bts_datasets(query="freight")
+
+        self.assertIn("Error searching BTS datasets", result)
+
+    async def test_query_passed_to_params(self):
+        with patch(
+            "mcp_govt_api.tools.bts.fetch_json",
+            new=AsyncMock(return_value={"results": []}),
+        ) as mock_fetch:
+            await search_bts_datasets(query="freight")
+
+        call_args = mock_fetch.call_args
+        params = call_args[1].get("params") or call_args[0][1]
+        self.assertEqual(params["q"], "freight")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 3 new tools: `get_airline_ontime_stats`, `get_border_crossing_data`, `search_bts_datasets`
- Uses BTS SODA API, no key required; 13 tests
Closes #79
🤖 Generated with [Claude Code](https://claude.com/claude-code)