### PR TITLE
Add SBA small business and disaster loan tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
 [![CI](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml/badge.svg)](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml)
-[![77 Tools](https://img.shields.io/badge/tools-77-2563eb.svg?style=flat-square)](#tool-reference)
-[![22 APIs](https://img.shields.io/badge/APIs-22-7c3aed.svg?style=flat-square)](#data-sources)
+[![80 Tools](https://img.shields.io/badge/tools-80-2563eb.svg?style=flat-square)](#tool-reference)
+[![23 APIs](https://img.shields.io/badge/APIs-23-7c3aed.svg?style=flat-square)](#data-sources)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776ab.svg?style=flat-square)](https://python.org)
 [![MCP](https://img.shields.io/badge/protocol-MCP-f97316.svg?style=flat-square)](https://modelcontextprotocol.io)
 
-An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **22 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, disaster management, FDA safety data, national parks, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
+An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **23 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, disaster management, FDA safety data, national parks, open data discovery, cybersecurity, SEC disclosures, Federal Reserve economic indicators, and SBA small business data.
 
 Built for practical agent workflows: concise high-level tools, raw query access where it matters, and location-aware inputs that accept city names, ZIP codes, addresses, or raw coordinates.
 
-No API keys required for 14 of 22 sources. Install it, point your MCP client at it, and start querying real civic data.
+No API keys required for 15 of 23 sources. Install it, point your MCP client at it, and start querying real civic data.
 
 [Get Started](#get-started) · [What's New](#whats-new) · [Data Sources](#data-sources) · [Tool Reference](#tool-reference) · [Roadmap](#implementation-roadmap) · [Contributing](CONTRIBUTING.md)
 
@@ -113,6 +113,12 @@ python3 -m mcp_govt_api
 |--------|---------------|-----|
 | [EIA](https://www.eia.gov/opendata/) | Electricity, petroleum, natural gas, coal, and energy market data | Required |
 
+### Small Business
+
+| Source | What It Covers | Key |
+|--------|---------------|-----|
+| [SBA](https://data.sba.gov) | Small business size standards, disaster loans, open datasets | -- |
+
 ### Finance & Securities
 
 | Source | What It Covers | Key |
@@ -183,6 +189,9 @@ python3 -m mcp_govt_api
 "What are the current gasoline prices?"
 "Show me electricity data for California"
 "What energy data categories does the EIA provide?"
+"Search SBA datasets for PPP loans"
+"What is the SBA size standard for restaurants?"
+"Show me SBA disaster loans in Florida"
 ```
 
 ---
@@ -338,6 +347,17 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 </details>
 
 <details>
+<summary><strong>SBA (Small Business)</strong> — 3 tools</summary>
+
+| Tool | Description |
+|------|-------------|
+| `search_sba_datasets` | Search SBA open datasets on data.sba.gov |
+| `get_sba_size_standards` | Look up small business size standards by industry or NAICS code |
+| `get_sba_disaster_loans` | Get SBA disaster loan data by state or year |
+
+</details>
+
+<details>
 <summary><strong>SEC EDGAR</strong> — 5 tools</summary>
 
 | Tool | Description |
@@ -478,6 +498,7 @@ API Availability:
   ✓ Space Weather         ✓ NASA FIRMS     ✓ NASA
   ✓ SEC EDGAR             ✓ CDC Open Data
   ✓ BLS                   ✓ FEMA
+  ✓ SBA
   ✗ OpenWeather (key not set)
   ✗ EIA (key not set)
 ```

--- a/src/mcp_govt_api/server.py
+++ b/src/mcp_govt_api/server.py
@@ -30,6 +30,7 @@ mcp = FastMCP(
 - NOAA CO-OPS (tide predictions, observed water levels, coastal stations)
 - NPS (national parks, park alerts, and park details)
 - EIA (electricity data, petroleum prices, energy market overview; requires API key)
+- SBA (small business size standards, disaster loans, open datasets)
 """,
 )
 
@@ -62,6 +63,7 @@ from mcp_govt_api.tools import (  # noqa: E402
     nps,  # noqa: F401
     openaq,  # noqa: F401
     safecast,  # noqa: F401
+    sba,  # noqa: F401
     sec,  # noqa: F401
     space_weather,  # noqa: F401
     usgs_water,  # noqa: F401

--- a/src/mcp_govt_api/tools/sba.py
+++ b/src/mcp_govt_api/tools/sba.py
@@ -1,0 +1,202 @@
+from mcp_govt_api.server import mcp
+from mcp_govt_api.utils.http import fetch_json
+
+SBA_CKAN_BASE = "https://data.sba.gov/api/3/action"
+SBA_DATA_BASE = "https://data.sba.gov/resource"
+
+# Socrata dataset identifiers on data.sba.gov
+SIZE_STANDARDS_DATASET = "jfx9-jbxa"
+DISASTER_LOANS_DATASET = "bnkb-3gaf"
+
+
+@mcp.tool()
+async def search_sba_datasets(query: str = "", limit: int = 10) -> str:
+    """Search SBA open datasets on data.sba.gov.
+
+    Queries the SBA CKAN data catalog to discover available datasets
+    related to small business programs, loans, size standards, and more.
+
+    Args:
+        query: Search terms (e.g., 'PPP loans', 'disaster', 'size standards')
+        limit: Maximum number of results to return (default: 10, max: 50)
+
+    Returns:
+        List of matching SBA datasets with titles, descriptions, and resource counts.
+    """
+    limit = min(limit, 50)
+    url = f"{SBA_CKAN_BASE}/package_search"
+    params: dict = {"q": query, "rows": limit}
+
+    try:
+        data = await fetch_json(url, params=params)
+    except Exception as e:
+        return f"Error searching SBA datasets: {e}"
+
+    results = data.get("result", {}).get("results", [])
+    total = data.get("result", {}).get("count", 0)
+
+    if not results:
+        return f"No SBA datasets found for '{query}'."
+
+    lines = [f"SBA Dataset Search: '{query}'"]
+    lines.append(f"Found {total} datasets (showing {len(results)})\n")
+
+    for ds in results:
+        title = ds.get("title", "Untitled")
+        org = ds.get("organization", {}).get("title", "SBA")
+        notes = ds.get("notes", "No description")[:200]
+        dataset_id = ds.get("id", "")
+        num_resources = len(ds.get("resources", []))
+
+        lines.append(f"**{title}**")
+        lines.append(f"  Organization: {org}")
+        lines.append(f"  Resources: {num_resources} files")
+        lines.append(f"  ID: `{dataset_id}`")
+        lines.append(f"  {notes}")
+        lines.append("")
+
+    lines.append("_Source: SBA Open Data (data.sba.gov)_")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_sba_size_standards(
+    industry: str = "",
+    naics_code: str = "",
+    limit: int = 10,
+) -> str:
+    """Look up SBA small business size standards by industry or NAICS code.
+
+    Size standards define the largest a business can be and still qualify
+    as a small business for federal programs and contracting.
+
+    Args:
+        industry: Industry name or keyword to search (e.g., 'restaurant',
+            'software', 'construction')
+        naics_code: NAICS industry code (e.g., '541511' for custom
+            computer programming)
+        limit: Maximum number of results to return (default: 10, max: 100)
+
+    Returns:
+        Size standard records showing NAICS code, industry description,
+        and the size standard (revenue or employee threshold).
+    """
+    limit = min(limit, 100)
+
+    url = f"{SBA_DATA_BASE}/{SIZE_STANDARDS_DATASET}.json"
+    params: dict = {"$limit": limit}
+
+    if naics_code:
+        params["NAICS_Code"] = naics_code
+    if industry:
+        params["$where"] = f"upper(NAICS_Industry_Description) like upper('%{industry}%')"
+
+    try:
+        data = await fetch_json(url, params=params)
+    except Exception as e:
+        return f"Error fetching SBA size standards: {e}"
+
+    if not isinstance(data, list):
+        data = []
+
+    if not data:
+        filter_parts = []
+        if industry:
+            filter_parts.append(f"industry '{industry}'")
+        if naics_code:
+            filter_parts.append(f"NAICS code '{naics_code}'")
+        filter_str = ", ".join(filter_parts) if filter_parts else "the given criteria"
+        return f"No SBA size standards found for {filter_str}."
+
+    lines = [f"SBA Size Standards ({len(data)} result(s)):\n"]
+
+    for r in data:
+        naics = r.get("NAICS_Code", r.get("naics_code", "N/A"))
+        desc = r.get("NAICS_Industry_Description", r.get("naics_industry_description", "Unknown"))
+        size_standard = r.get("Size_Standard", r.get("size_standard", "N/A"))
+
+        lines.append(f"**NAICS {naics}** - {desc}")
+        lines.append(f"  Size Standard: {size_standard}")
+        lines.append("")
+
+    lines.append("_Source: SBA Size Standards (data.sba.gov)_")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_sba_disaster_loans(
+    state: str = "",
+    year: str = "",
+    limit: int = 20,
+) -> str:
+    """Get SBA disaster loan data by state or year.
+
+    Queries SBA disaster loan approval data from data.sba.gov. These loans
+    help businesses and homeowners recover from declared disasters.
+
+    Args:
+        state: Two-letter state abbreviation (e.g., 'CA', 'TX', 'FL')
+        year: Filter by fiscal year (e.g., '2024')
+        limit: Maximum number of results to return (default: 20, max: 100)
+
+    Returns:
+        Disaster loan records showing loan amounts, declaration numbers,
+        damage categories, and location information.
+    """
+    limit = min(limit, 100)
+
+    url = f"{SBA_DATA_BASE}/{DISASTER_LOANS_DATASET}.json"
+    params: dict = {"$limit": limit, "$order": ":id DESC"}
+
+    where_clauses = []
+    if state:
+        where_clauses.append(f"upper(damaged_state_abbreviation) = upper('{state}')")
+    if year:
+        where_clauses.append(f"fiscal_year = '{year}'")
+
+    if where_clauses:
+        params["$where"] = " AND ".join(where_clauses)
+
+    try:
+        data = await fetch_json(url, params=params)
+    except Exception as e:
+        return f"Error fetching SBA disaster loans: {e}"
+
+    if not isinstance(data, list):
+        data = []
+
+    if not data:
+        filter_parts = []
+        if state:
+            filter_parts.append(f"state '{state.upper()}'")
+        if year:
+            filter_parts.append(f"year '{year}'")
+        filter_str = ", ".join(filter_parts) if filter_parts else "the given criteria"
+        return f"No SBA disaster loans found for {filter_str}."
+
+    lines = [f"SBA Disaster Loans ({len(data)} result(s)):\n"]
+
+    for r in data:
+        decl_num = r.get("fema_disaster_number", r.get("declaration_number", "N/A"))
+        loan_state = r.get("damaged_state_abbreviation", "N/A")
+        county = r.get("damaged_county", "Unknown")
+        damage_cat = r.get("damage_category", "N/A")
+        total_approved = r.get("total_approved_loan_amount", r.get("approved_amount", ""))
+        fy = r.get("fiscal_year", "N/A")
+
+        lines.append(f"**Disaster #{decl_num}** - {county}, {loan_state}")
+        lines.append(f"  Fiscal Year: {fy}")
+        lines.append(f"  Damage Category: {damage_cat}")
+        if total_approved:
+            try:
+                amount = float(total_approved)
+                lines.append(f"  Approved Amount: ${amount:,.2f}")
+            except (ValueError, TypeError):
+                lines.append(f"  Approved Amount: {total_approved}")
+        lines.append("")
+
+    lines.append("_Source: SBA Disaster Loans (data.sba.gov)_")
+
+    return "\n".join(lines)

--- a/tests/test_sba.py
+++ b/tests/test_sba.py
@@ -1,0 +1,199 @@
+"""Tests for SBA small business and disaster loan tools."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from mcp_govt_api.tools.sba import (
+    get_sba_disaster_loans,
+    get_sba_size_standards,
+    search_sba_datasets,
+)
+
+
+class TestSearchSbaDatasets(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_datasets(self):
+        mock_data = {
+            "result": {
+                "count": 25,
+                "results": [
+                    {
+                        "title": "PPP FOIA Dataset",
+                        "organization": {"title": "SBA"},
+                        "notes": "Paycheck Protection Program loan data",
+                        "id": "abc-123",
+                        "resources": [{"id": "r1"}, {"id": "r2"}],
+                    },
+                ],
+            }
+        }
+
+        with patch(
+            "mcp_govt_api.tools.sba.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await search_sba_datasets(query="PPP loans", limit=5)
+
+        self.assertIn("PPP FOIA Dataset", result)
+        self.assertIn("SBA", result)
+        self.assertIn("25 datasets", result)
+        self.assertIn("2 files", result)
+        self.assertIn("abc-123", result)
+
+    async def test_empty_results(self):
+        mock_data = {"result": {"count": 0, "results": []}}
+
+        with patch(
+            "mcp_govt_api.tools.sba.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await search_sba_datasets(query="nonexistent")
+
+        self.assertIn("No SBA datasets found", result)
+
+    async def test_handles_api_error(self):
+        with patch(
+            "mcp_govt_api.tools.sba.fetch_json",
+            new=AsyncMock(side_effect=Exception("Connection failed")),
+        ):
+            result = await search_sba_datasets(query="loans")
+
+        self.assertIn("Error searching SBA datasets", result)
+        self.assertIn("Connection failed", result)
+
+
+class TestGetSbaSizeStandards(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_size_standards(self):
+        mock_data = [
+            {
+                "NAICS_Code": "541511",
+                "NAICS_Industry_Description": "Custom Computer Programming Services",
+                "Size_Standard": "$34.0 Million",
+            },
+        ]
+
+        with patch(
+            "mcp_govt_api.tools.sba.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await get_sba_size_standards(naics_code="541511")
+
+        self.assertIn("541511", result)
+        self.assertIn("Custom Computer Programming Services", result)
+        self.assertIn("$34.0 Million", result)
+
+    async def test_search_by_industry(self):
+        mock_data = [
+            {
+                "NAICS_Code": "722511",
+                "NAICS_Industry_Description": "Full-Service Restaurants",
+                "Size_Standard": "$10.0 Million",
+            },
+        ]
+
+        with patch(
+            "mcp_govt_api.tools.sba.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ) as mock_fetch:
+            result = await get_sba_size_standards(industry="restaurant")
+
+        self.assertIn("Full-Service Restaurants", result)
+        self.assertIn("$10.0 Million", result)
+        call_args = mock_fetch.call_args
+        params = call_args[1].get("params") or call_args[0][1]
+        self.assertIn("restaurant", params["$where"])
+
+    async def test_empty_results(self):
+        mock_data = []
+
+        with patch(
+            "mcp_govt_api.tools.sba.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await get_sba_size_standards(naics_code="000000")
+
+        self.assertIn("No SBA size standards found", result)
+
+    async def test_handles_api_error(self):
+        with patch(
+            "mcp_govt_api.tools.sba.fetch_json",
+            new=AsyncMock(side_effect=Exception("Timeout")),
+        ):
+            result = await get_sba_size_standards(industry="tech")
+
+        self.assertIn("Error fetching SBA size standards", result)
+        self.assertIn("Timeout", result)
+
+
+class TestGetSbaDisasterLoans(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_disaster_loans(self):
+        mock_data = [
+            {
+                "fema_disaster_number": "4699",
+                "damaged_state_abbreviation": "FL",
+                "damaged_county": "Lee County",
+                "damage_category": "Real Property",
+                "total_approved_loan_amount": "150000.00",
+                "fiscal_year": "2023",
+            },
+        ]
+
+        with patch(
+            "mcp_govt_api.tools.sba.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await get_sba_disaster_loans(state="FL", limit=5)
+
+        self.assertIn("4699", result)
+        self.assertIn("FL", result)
+        self.assertIn("Lee County", result)
+        self.assertIn("Real Property", result)
+        self.assertIn("$150,000.00", result)
+        self.assertIn("2023", result)
+
+    async def test_filter_by_year(self):
+        mock_data = [
+            {
+                "fema_disaster_number": "4800",
+                "damaged_state_abbreviation": "TX",
+                "damaged_county": "Harris County",
+                "damage_category": "Economic Injury",
+                "total_approved_loan_amount": "50000.00",
+                "fiscal_year": "2024",
+            },
+        ]
+
+        with patch(
+            "mcp_govt_api.tools.sba.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ) as mock_fetch:
+            result = await get_sba_disaster_loans(year="2024")
+
+        self.assertIn("Harris County", result)
+        call_args = mock_fetch.call_args
+        params = call_args[1].get("params") or call_args[0][1]
+        self.assertIn("fiscal_year = '2024'", params["$where"])
+
+    async def test_empty_results(self):
+        mock_data = []
+
+        with patch(
+            "mcp_govt_api.tools.sba.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await get_sba_disaster_loans(state="ZZ")
+
+        self.assertIn("No SBA disaster loans found", result)
+
+    async def test_handles_api_error(self):
+        with patch(
+            "mcp_govt_api.tools.sba.fetch_json",
+            new=AsyncMock(side_effect=Exception("Server error")),
+        ):
+            result = await get_sba_disaster_loans(state="CA")
+
+        self.assertIn("Error fetching SBA disaster loans", result)
+        self.assertIn("Server error", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 3 new tools: `search_sba_datasets`, `get_sba_size_standards`, `get_sba_disaster_loans`
- Uses SBA CKAN/Socrata APIs, no key required; 11 tests
Closes #78
🤖 Generated with [Claude Code](https://claude.com/claude-code)