### PR TITLE
Add CFPB consumer complaint and financial protection tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
 [![CI](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml/badge.svg)](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml)
-[![77 Tools](https://img.shields.io/badge/tools-77-2563eb.svg?style=flat-square)](#tool-reference)
-[![22 APIs](https://img.shields.io/badge/APIs-22-7c3aed.svg?style=flat-square)](#data-sources)
+[![80 Tools](https://img.shields.io/badge/tools-80-2563eb.svg?style=flat-square)](#tool-reference)
+[![23 APIs](https://img.shields.io/badge/APIs-23-7c3aed.svg?style=flat-square)](#data-sources)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776ab.svg?style=flat-square)](https://python.org)
 [![MCP](https://img.shields.io/badge/protocol-MCP-f97316.svg?style=flat-square)](https://modelcontextprotocol.io)
 
-An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **22 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, disaster management, FDA safety data, national parks, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
+An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **23 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, disaster management, FDA safety data, national parks, consumer financial protection, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
 
 Built for practical agent workflows: concise high-level tools, raw query access where it matters, and location-aware inputs that accept city names, ZIP codes, addresses, or raw coordinates.
 
-No API keys required for 14 of 22 sources. Install it, point your MCP client at it, and start querying real civic data.
+No API keys required for 15 of 23 sources. Install it, point your MCP client at it, and start querying real civic data.
 
 [Get Started](#get-started) · [What's New](#whats-new) · [Data Sources](#data-sources) · [Tool Reference](#tool-reference) · [Roadmap](#implementation-roadmap) · [Contributing](CONTRIBUTING.md)
 
@@ -113,11 +113,12 @@ python3 -m mcp_govt_api
 |--------|---------------|-----|
 | [EIA](https://www.eia.gov/opendata/) | Electricity, petroleum, natural gas, coal, and energy market data | Required |
 
-### Finance & Securities
+### Finance & Consumer Protection
 
 | Source | What It Covers | Key |
 |--------|---------------|-----|
 | [SEC EDGAR](https://sec.gov/edgar) | Company filings, 10-K, 10-Q, 8-K forms | -- |
+| [CFPB](https://www.consumerfinance.gov) | Consumer complaints, financial product issues, company responses | -- |
 
 ### Public Health
 
@@ -169,6 +170,8 @@ python3 -m mcp_govt_api
 "Show me vaccination coverage data for Influenza"
 "Are there any known exploited vulnerabilities for Microsoft products?"
 "What are the latest CISA security alerts?"
+"Show me consumer complaints about mortgages in California"
+"What are the most common complaint types filed with the CFPB?"
 "What's the current CPI?"
 "What's the unemployment rate in California?"
 "Show me BLS employment data for 2023"
@@ -351,6 +354,17 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 </details>
 
 <details>
+<summary><strong>CFPB Consumer Complaints</strong> — 3 tools</summary>
+
+| Tool | Description |
+|------|-------------|
+| `search_cfpb_complaints` | Search consumer complaints by product, company, state, or keyword |
+| `get_cfpb_complaint` | Get full details of a specific consumer complaint by ID |
+| `get_cfpb_complaint_stats` | Aggregate complaint statistics by product, company, or state |
+
+</details>
+
+<details>
 <summary><strong>National Parks (NPS)</strong> — 3 tools</summary>
 
 | Tool | Description |
@@ -528,7 +542,7 @@ The active roadmap lives in [#87](https://github.com/EricGrill/mcp-civic-data/is
 
 - [#49](https://github.com/EricGrill/mcp-civic-data/issues/49) Add composite queries for multi-source data aggregation
 - [#59](https://github.com/EricGrill/mcp-civic-data/issues/59) Add EIA energy market and grid tools
-- [#75](https://github.com/EricGrill/mcp-civic-data/issues/75) Add CFPB consumer complaint and financial protection tools
+- ~~[#75](https://github.com/EricGrill/mcp-civic-data/issues/75) Add CFPB consumer complaint and financial protection tools~~
 - [#79](https://github.com/EricGrill/mcp-civic-data/issues/79) Add BTS freight and transportation performance tools
 - [#82](https://github.com/EricGrill/mcp-civic-data/issues/82) Add SEC filings and company disclosure tools
 - [#83](https://github.com/EricGrill/mcp-civic-data/issues/83) Add BEA regional and national economic accounts tools

--- a/src/mcp_govt_api/server.py
+++ b/src/mcp_govt_api/server.py
@@ -30,6 +30,7 @@ mcp = FastMCP(
 - NOAA CO-OPS (tide predictions, observed water levels, coastal stations)
 - NPS (national parks, park alerts, and park details)
 - EIA (electricity data, petroleum prices, energy market overview; requires API key)
+- CFPB (consumer complaints, financial product issues, company response data)
 """,
 )
 
@@ -45,6 +46,7 @@ from mcp_govt_api.tools import (  # noqa: E402
     bls,  # noqa: F401
     cdc,  # noqa: F401
     census,  # noqa: F401
+    cfpb,  # noqa: F401
     cisa,  # noqa: F401
     datagov,  # noqa: F401
     earthquakes,  # noqa: F401

--- a/src/mcp_govt_api/tools/cfpb.py
+++ b/src/mcp_govt_api/tools/cfpb.py
@@ -1,0 +1,310 @@
+from mcp_govt_api.server import mcp
+from mcp_govt_api.utils.http import fetch_json
+
+CFPB_BASE_URL = "https://www.consumerfinance.gov/data-research/consumer-complaints/search/api/v1/"
+
+
+@mcp.tool()
+async def search_cfpb_complaints(
+    query: str = "",
+    product: str = "",
+    company: str = "",
+    state: str = "",
+    date_received_min: str = "",
+    date_received_max: str = "",
+    limit: int = 10,
+) -> str:
+    """Search the CFPB Consumer Complaint Database.
+
+    The Consumer Financial Protection Bureau collects complaints about
+    financial products and services. This tool searches complaints
+    submitted by consumers against financial companies.
+
+    Args:
+        query: Search term in complaint narratives (e.g., 'mortgage', 'debt collection')
+        product: Filter by product type (e.g., 'Mortgage', 'Credit card',
+                 'Student loan', 'Debt collection', 'Credit reporting')
+        company: Filter by company name (e.g., 'Bank of America', 'Wells Fargo')
+        state: Two-letter US state code (e.g., 'CA', 'NY', 'TX')
+        date_received_min: Start date in YYYY-MM-DD format (e.g., '2024-01-01')
+        date_received_max: End date in YYYY-MM-DD format (e.g., '2024-12-31')
+        limit: Maximum number of results to return (default: 10, max: 100)
+
+    Returns:
+        List of consumer complaints with product, issue, company, state,
+        date received, and company response details.
+    """
+    limit = min(max(1, limit), 100)
+
+    params = {
+        "size": str(limit),
+        "sort": "created_date_desc",
+    }
+
+    if query:
+        params["search_term"] = query
+    if product:
+        params["product"] = product
+    if company:
+        params["company"] = company
+    if state:
+        params["state"] = state.upper()
+    if date_received_min:
+        params["date_received_min"] = date_received_min
+    if date_received_max:
+        params["date_received_max"] = date_received_max
+
+    try:
+        data = await fetch_json(CFPB_BASE_URL, params=params)
+    except Exception as e:
+        return f"Error fetching CFPB complaints: {e}"
+
+    hits = data.get("hits", {}).get("hits", [])
+    total = data.get("hits", {}).get("total", {}).get("value", 0)
+
+    if not hits:
+        filters = []
+        if query:
+            filters.append(f"query '{query}'")
+        if product:
+            filters.append(f"product '{product}'")
+        if company:
+            filters.append(f"company '{company}'")
+        if state:
+            filters.append(f"state '{state.upper()}'")
+        filter_str = " and ".join(filters) if filters else "the given criteria"
+        return f"No CFPB complaints found matching {filter_str}."
+
+    lines = [f"CFPB Consumer Complaints ({len(hits)} of {total} total):\n"]
+
+    for hit in hits:
+        source = hit.get("_source", {})
+        complaint_id = source.get("complaint_id", "N/A")
+        prod = source.get("product", "N/A")
+        sub_product = source.get("sub_product", "")
+        issue = source.get("issue", "N/A")
+        sub_issue = source.get("sub_issue", "")
+        comp = source.get("company", "N/A")
+        comp_state = source.get("state", "N/A")
+        date_received = source.get("date_received", "N/A")
+        company_response = source.get("company_response", "N/A")
+        timely = source.get("timely", "N/A")
+        consumer_disputed = source.get("consumer_disputed", "N/A")
+
+        lines.append(f"**Complaint #{complaint_id}**")
+        product_str = f"{prod} — {sub_product}" if sub_product else prod
+        lines.append(f"  Product: {product_str}")
+        issue_str = f"{issue} — {sub_issue}" if sub_issue else issue
+        lines.append(f"  Issue: {issue_str}")
+        lines.append(f"  Company: {comp}")
+        lines.append(f"  State: {comp_state}")
+        lines.append(f"  Date Received: {date_received}")
+        lines.append(f"  Company Response: {company_response}")
+        lines.append(f"  Timely Response: {timely}")
+        if consumer_disputed and consumer_disputed != "N/A":
+            lines.append(f"  Consumer Disputed: {consumer_disputed}")
+        lines.append("")
+
+    lines.append(f"\n_Total matching complaints: {total}_")
+    lines.append("_Source: CFPB Consumer Complaint Database_")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_cfpb_complaint(complaint_id: str) -> str:
+    """Get details of a specific CFPB consumer complaint by ID.
+
+    Retrieves the full details of a single consumer complaint from the
+    CFPB Consumer Complaint Database.
+
+    Args:
+        complaint_id: The CFPB complaint ID number (e.g., '3648850')
+
+    Returns:
+        Full complaint details including product, issue, company, narrative,
+        company response, and resolution status.
+    """
+    if not complaint_id:
+        return "Error: complaint_id is required."
+
+    url = f"{CFPB_BASE_URL}{complaint_id}"
+
+    try:
+        data = await fetch_json(url)
+    except Exception as e:
+        return f"Error fetching CFPB complaint {complaint_id}: {e}"
+
+    source = data.get("_source", data)
+    if not source:
+        return f"No complaint found with ID {complaint_id}."
+
+    cid = source.get("complaint_id", complaint_id)
+    product = source.get("product", "N/A")
+    sub_product = source.get("sub_product", "")
+    issue = source.get("issue", "N/A")
+    sub_issue = source.get("sub_issue", "")
+    company = source.get("company", "N/A")
+    state = source.get("state", "N/A")
+    zip_code = source.get("zip_code", "N/A")
+    date_received = source.get("date_received", "N/A")
+    date_sent = source.get("date_sent_to_company", "N/A")
+    company_response = source.get("company_response", "N/A")
+    company_public_response = source.get("company_public_response", "")
+    timely = source.get("timely", "N/A")
+    consumer_disputed = source.get("consumer_disputed", "")
+    consumer_consent = source.get("consumer_consent_provided", "")
+    submitted_via = source.get("submitted_via", "N/A")
+    narrative = source.get("complaint_what_happened", "")
+    tags = source.get("tags", "")
+
+    lines = [f"**CFPB Complaint #{cid}**\n"]
+
+    product_str = f"{product} — {sub_product}" if sub_product else product
+    lines.append(f"Product: {product_str}")
+    issue_str = f"{issue} — {sub_issue}" if sub_issue else issue
+    lines.append(f"Issue: {issue_str}")
+    lines.append(f"Company: {company}")
+    lines.append(f"State: {state}")
+    lines.append(f"ZIP Code: {zip_code}")
+    lines.append(f"Date Received: {date_received}")
+    lines.append(f"Date Sent to Company: {date_sent}")
+    lines.append(f"Submitted Via: {submitted_via}")
+    if tags:
+        lines.append(f"Tags: {tags}")
+    lines.append("")
+    lines.append(f"**Company Response:** {company_response}")
+    if company_public_response:
+        lines.append(f"**Public Response:** {company_public_response}")
+    lines.append(f"Timely Response: {timely}")
+    if consumer_disputed:
+        lines.append(f"Consumer Disputed: {consumer_disputed}")
+    if consumer_consent:
+        lines.append(f"Consumer Consent Provided: {consumer_consent}")
+
+    if narrative:
+        lines.append(f"\n**Consumer Narrative:**")
+        if len(narrative) > 1000:
+            lines.append(narrative[:1000] + "...")
+        else:
+            lines.append(narrative)
+
+    lines.append(f"\n_Source: CFPB Consumer Complaint Database_")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_cfpb_complaint_stats(
+    product: str = "",
+    company: str = "",
+    state: str = "",
+    date_received_min: str = "",
+    date_received_max: str = "",
+) -> str:
+    """Get aggregate statistics on CFPB consumer complaints.
+
+    Queries the CFPB Consumer Complaint Database to provide summary
+    statistics, including total complaint counts broken down by product,
+    issue, and company response type.
+
+    Args:
+        product: Filter by product type (e.g., 'Mortgage', 'Credit card')
+        company: Filter by company name (e.g., 'Bank of America')
+        state: Two-letter US state code (e.g., 'CA', 'NY')
+        date_received_min: Start date in YYYY-MM-DD format
+        date_received_max: End date in YYYY-MM-DD format
+
+    Returns:
+        Summary statistics including total complaints, top products,
+        top issues, and company response breakdown.
+    """
+    params = {
+        "size": "0",
+        "sort": "created_date_desc",
+    }
+
+    if product:
+        params["product"] = product
+    if company:
+        params["company"] = company
+    if state:
+        params["state"] = state.upper()
+    if date_received_min:
+        params["date_received_min"] = date_received_min
+    if date_received_max:
+        params["date_received_max"] = date_received_max
+
+    try:
+        data = await fetch_json(CFPB_BASE_URL, params=params)
+    except Exception as e:
+        return f"Error fetching CFPB complaint stats: {e}"
+
+    total = data.get("hits", {}).get("total", {}).get("value", 0)
+
+    aggs = data.get("aggregations", {})
+
+    lines = ["**CFPB Consumer Complaint Statistics**\n"]
+
+    filter_parts = []
+    if product:
+        filter_parts.append(f"Product: {product}")
+    if company:
+        filter_parts.append(f"Company: {company}")
+    if state:
+        filter_parts.append(f"State: {state.upper()}")
+    if date_received_min or date_received_max:
+        date_range = f"{date_received_min or 'start'} to {date_received_max or 'present'}"
+        filter_parts.append(f"Date Range: {date_range}")
+
+    if filter_parts:
+        lines.append("Filters: " + ", ".join(filter_parts))
+
+    lines.append(f"Total Complaints: {total:,}\n")
+
+    product_agg = aggs.get("product", {})
+    product_buckets = product_agg.get("product", {}).get("buckets", [])
+    if product_buckets:
+        lines.append("**Top Products:**")
+        for bucket in product_buckets[:10]:
+            key = bucket.get("key", "Unknown")
+            count = bucket.get("doc_count", 0)
+            lines.append(f"  - {key}: {count:,}")
+        lines.append("")
+
+    issue_agg = aggs.get("issue", {})
+    issue_buckets = issue_agg.get("issue", {}).get("buckets", [])
+    if issue_buckets:
+        lines.append("**Top Issues:**")
+        for bucket in issue_buckets[:10]:
+            key = bucket.get("key", "Unknown")
+            count = bucket.get("doc_count", 0)
+            lines.append(f"  - {key}: {count:,}")
+        lines.append("")
+
+    company_response_agg = aggs.get("company_response", {})
+    response_buckets = company_response_agg.get("company_response", {}).get("buckets", [])
+    if response_buckets:
+        lines.append("**Company Response Breakdown:**")
+        for bucket in response_buckets[:10]:
+            key = bucket.get("key", "Unknown")
+            count = bucket.get("doc_count", 0)
+            lines.append(f"  - {key}: {count:,}")
+        lines.append("")
+
+    company_agg = aggs.get("company", {})
+    company_buckets = company_agg.get("company", {}).get("buckets", [])
+    if company_buckets:
+        lines.append("**Top Companies by Complaint Volume:**")
+        for bucket in company_buckets[:10]:
+            key = bucket.get("key", "Unknown")
+            count = bucket.get("doc_count", 0)
+            lines.append(f"  - {key}: {count:,}")
+        lines.append("")
+
+    if not any([product_buckets, issue_buckets, response_buckets, company_buckets]):
+        lines.append("No aggregation data available for the given filters.")
+
+    lines.append("_Source: CFPB Consumer Complaint Database_")
+
+    return "\n".join(lines)

--- a/tests/test_cfpb.py
+++ b/tests/test_cfpb.py
@@ -1,0 +1,326 @@
+"""Tests for CFPB consumer complaint tools."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+
+class TestSearchCfpbComplaints(unittest.IsolatedAsyncioTestCase):
+    """Tests for search_cfpb_complaints tool."""
+
+    @patch("mcp_govt_api.tools.cfpb.fetch_json", new_callable=AsyncMock)
+    async def test_search_basic(self, mock_fetch):
+        from mcp_govt_api.tools.cfpb import search_cfpb_complaints
+
+        mock_fetch.return_value = {
+            "hits": {
+                "total": {"value": 1},
+                "hits": [
+                    {
+                        "_source": {
+                            "complaint_id": "1234567",
+                            "product": "Mortgage",
+                            "sub_product": "Conventional home mortgage",
+                            "issue": "Trouble during payment process",
+                            "sub_issue": "",
+                            "company": "Test Bank Inc",
+                            "state": "CA",
+                            "date_received": "2024-03-15",
+                            "company_response": "Closed with explanation",
+                            "timely": "Yes",
+                            "consumer_disputed": "No",
+                        }
+                    }
+                ],
+            }
+        }
+
+        result = await search_cfpb_complaints(query="mortgage", state="CA", limit=5)
+
+        self.assertIn("Complaint #1234567", result)
+        self.assertIn("Mortgage", result)
+        self.assertIn("Test Bank Inc", result)
+        self.assertIn("CA", result)
+        self.assertIn("Closed with explanation", result)
+        mock_fetch.assert_called_once()
+        call_args = mock_fetch.call_args
+        params = call_args[1].get("params") or call_args[0][1]
+        self.assertEqual(params["search_term"], "mortgage")
+        self.assertEqual(params["state"], "CA")
+        self.assertEqual(params["size"], "5")
+
+    @patch("mcp_govt_api.tools.cfpb.fetch_json", new_callable=AsyncMock)
+    async def test_search_no_results(self, mock_fetch):
+        from mcp_govt_api.tools.cfpb import search_cfpb_complaints
+
+        mock_fetch.return_value = {
+            "hits": {"total": {"value": 0}, "hits": []},
+        }
+
+        result = await search_cfpb_complaints(product="Nonexistent product")
+
+        self.assertIn("No CFPB complaints found", result)
+
+    @patch("mcp_govt_api.tools.cfpb.fetch_json", new_callable=AsyncMock)
+    async def test_search_api_error(self, mock_fetch):
+        from mcp_govt_api.tools.cfpb import search_cfpb_complaints
+
+        mock_fetch.side_effect = Exception("API unavailable")
+
+        result = await search_cfpb_complaints()
+
+        self.assertIn("Error fetching CFPB complaints", result)
+
+    @patch("mcp_govt_api.tools.cfpb.fetch_json", new_callable=AsyncMock)
+    async def test_search_with_all_filters(self, mock_fetch):
+        from mcp_govt_api.tools.cfpb import search_cfpb_complaints
+
+        mock_fetch.return_value = {
+            "hits": {
+                "total": {"value": 1},
+                "hits": [
+                    {
+                        "_source": {
+                            "complaint_id": "9999999",
+                            "product": "Credit card",
+                            "sub_product": "",
+                            "issue": "Billing disputes",
+                            "sub_issue": "",
+                            "company": "Big Bank Corp",
+                            "state": "NY",
+                            "date_received": "2024-06-01",
+                            "company_response": "Closed with monetary relief",
+                            "timely": "Yes",
+                            "consumer_disputed": "",
+                        }
+                    }
+                ],
+            }
+        }
+
+        result = await search_cfpb_complaints(
+            query="billing",
+            product="Credit card",
+            company="Big Bank Corp",
+            state="NY",
+            date_received_min="2024-01-01",
+            date_received_max="2024-12-31",
+        )
+
+        self.assertIn("Credit card", result)
+        self.assertIn("Big Bank Corp", result)
+        call_args = mock_fetch.call_args
+        params = call_args[1].get("params") or call_args[0][1]
+        self.assertEqual(params["product"], "Credit card")
+        self.assertEqual(params["company"], "Big Bank Corp")
+        self.assertEqual(params["date_received_min"], "2024-01-01")
+        self.assertEqual(params["date_received_max"], "2024-12-31")
+
+    @patch("mcp_govt_api.tools.cfpb.fetch_json", new_callable=AsyncMock)
+    async def test_search_limits_capped(self, mock_fetch):
+        from mcp_govt_api.tools.cfpb import search_cfpb_complaints
+
+        mock_fetch.return_value = {
+            "hits": {"total": {"value": 0}, "hits": []},
+        }
+
+        await search_cfpb_complaints(limit=200)
+
+        call_args = mock_fetch.call_args
+        params = call_args[1].get("params") or call_args[0][1]
+        self.assertEqual(params["size"], "100")
+
+
+class TestGetCfpbComplaint(unittest.IsolatedAsyncioTestCase):
+    """Tests for get_cfpb_complaint tool."""
+
+    @patch("mcp_govt_api.tools.cfpb.fetch_json", new_callable=AsyncMock)
+    async def test_get_complaint_basic(self, mock_fetch):
+        from mcp_govt_api.tools.cfpb import get_cfpb_complaint
+
+        mock_fetch.return_value = {
+            "_source": {
+                "complaint_id": "3648850",
+                "product": "Mortgage",
+                "sub_product": "FHA mortgage",
+                "issue": "Applying for a mortgage",
+                "sub_issue": "Application denial",
+                "company": "Test Lender LLC",
+                "state": "TX",
+                "zip_code": "75001",
+                "date_received": "2024-02-10",
+                "date_sent_to_company": "2024-02-11",
+                "company_response": "Closed with explanation",
+                "company_public_response": "",
+                "timely": "Yes",
+                "consumer_disputed": "",
+                "consumer_consent_provided": "Consent provided",
+                "submitted_via": "Web",
+                "complaint_what_happened": "I was denied a mortgage.",
+                "tags": "",
+            }
+        }
+
+        result = await get_cfpb_complaint("3648850")
+
+        self.assertIn("Complaint #3648850", result)
+        self.assertIn("Mortgage", result)
+        self.assertIn("FHA mortgage", result)
+        self.assertIn("Test Lender LLC", result)
+        self.assertIn("TX", result)
+        self.assertIn("I was denied a mortgage.", result)
+        self.assertIn("Consent provided", result)
+
+    async def test_get_complaint_no_id(self):
+        from mcp_govt_api.tools.cfpb import get_cfpb_complaint
+
+        result = await get_cfpb_complaint("")
+
+        self.assertIn("Error: complaint_id is required", result)
+
+    @patch("mcp_govt_api.tools.cfpb.fetch_json", new_callable=AsyncMock)
+    async def test_get_complaint_api_error(self, mock_fetch):
+        from mcp_govt_api.tools.cfpb import get_cfpb_complaint
+
+        mock_fetch.side_effect = Exception("Not found")
+
+        result = await get_cfpb_complaint("0000000")
+
+        self.assertIn("Error fetching CFPB complaint", result)
+
+    @patch("mcp_govt_api.tools.cfpb.fetch_json", new_callable=AsyncMock)
+    async def test_get_complaint_long_narrative_truncated(self, mock_fetch):
+        from mcp_govt_api.tools.cfpb import get_cfpb_complaint
+
+        long_narrative = "A" * 2000
+        mock_fetch.return_value = {
+            "_source": {
+                "complaint_id": "1111111",
+                "product": "Student loan",
+                "sub_product": "",
+                "issue": "Repayment",
+                "sub_issue": "",
+                "company": "Loan Co",
+                "state": "FL",
+                "zip_code": "33101",
+                "date_received": "2024-01-01",
+                "date_sent_to_company": "2024-01-02",
+                "company_response": "Closed",
+                "company_public_response": "",
+                "timely": "Yes",
+                "consumer_disputed": "",
+                "consumer_consent_provided": "",
+                "submitted_via": "Web",
+                "complaint_what_happened": long_narrative,
+                "tags": "",
+            }
+        }
+
+        result = await get_cfpb_complaint("1111111")
+
+        self.assertIn("...", result)
+        self.assertNotIn("A" * 2000, result)
+
+
+class TestGetCfpbComplaintStats(unittest.IsolatedAsyncioTestCase):
+    """Tests for get_cfpb_complaint_stats tool."""
+
+    @patch("mcp_govt_api.tools.cfpb.fetch_json", new_callable=AsyncMock)
+    async def test_stats_basic(self, mock_fetch):
+        from mcp_govt_api.tools.cfpb import get_cfpb_complaint_stats
+
+        mock_fetch.return_value = {
+            "hits": {"total": {"value": 50000}},
+            "aggregations": {
+                "product": {
+                    "product": {
+                        "buckets": [
+                            {"key": "Mortgage", "doc_count": 20000},
+                            {"key": "Credit card", "doc_count": 15000},
+                        ]
+                    }
+                },
+                "issue": {
+                    "issue": {
+                        "buckets": [
+                            {"key": "Trouble during payment process", "doc_count": 10000},
+                        ]
+                    }
+                },
+                "company_response": {
+                    "company_response": {
+                        "buckets": [
+                            {"key": "Closed with explanation", "doc_count": 30000},
+                        ]
+                    }
+                },
+                "company": {
+                    "company": {
+                        "buckets": [
+                            {"key": "Bank of America", "doc_count": 5000},
+                        ]
+                    }
+                },
+            },
+        }
+
+        result = await get_cfpb_complaint_stats(state="CA")
+
+        self.assertIn("50,000", result)
+        self.assertIn("Mortgage", result)
+        self.assertIn("20,000", result)
+        self.assertIn("Credit card", result)
+        self.assertIn("Trouble during payment process", result)
+        self.assertIn("Closed with explanation", result)
+        self.assertIn("Bank of America", result)
+        self.assertIn("State: CA", result)
+        call_args = mock_fetch.call_args
+        params = call_args[1].get("params") or call_args[0][1]
+        self.assertEqual(params["size"], "0")
+
+    @patch("mcp_govt_api.tools.cfpb.fetch_json", new_callable=AsyncMock)
+    async def test_stats_no_aggregations(self, mock_fetch):
+        from mcp_govt_api.tools.cfpb import get_cfpb_complaint_stats
+
+        mock_fetch.return_value = {
+            "hits": {"total": {"value": 0}},
+            "aggregations": {},
+        }
+
+        result = await get_cfpb_complaint_stats(product="Nonexistent")
+
+        self.assertIn("Total Complaints: 0", result)
+        self.assertIn("No aggregation data available", result)
+
+    @patch("mcp_govt_api.tools.cfpb.fetch_json", new_callable=AsyncMock)
+    async def test_stats_api_error(self, mock_fetch):
+        from mcp_govt_api.tools.cfpb import get_cfpb_complaint_stats
+
+        mock_fetch.side_effect = Exception("Server error")
+
+        result = await get_cfpb_complaint_stats()
+
+        self.assertIn("Error fetching CFPB complaint stats", result)
+
+    @patch("mcp_govt_api.tools.cfpb.fetch_json", new_callable=AsyncMock)
+    async def test_stats_with_date_filters(self, mock_fetch):
+        from mcp_govt_api.tools.cfpb import get_cfpb_complaint_stats
+
+        mock_fetch.return_value = {
+            "hits": {"total": {"value": 100}},
+            "aggregations": {},
+        }
+
+        result = await get_cfpb_complaint_stats(
+            date_received_min="2024-01-01",
+            date_received_max="2024-06-30",
+        )
+
+        self.assertIn("Date Range: 2024-01-01 to 2024-06-30", result)
+        call_args = mock_fetch.call_args
+        params = call_args[1].get("params") or call_args[0][1]
+        self.assertEqual(params["date_received_min"], "2024-01-01")
+        self.assertEqual(params["date_received_max"], "2024-06-30")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 3 new tools: `search_cfpb_complaints`, `get_cfpb_complaint`, `get_cfpb_complaint_stats`
- Uses CFPB Consumer Complaint Database API, no key required; 13 tests
Closes #75
🤖 Generated with [Claude Code](https://claude.com/claude-code)