### PR TITLE
Add CMS healthcare provider and hospital quality tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
 [![CI](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml/badge.svg)](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml)
-[![77 Tools](https://img.shields.io/badge/tools-77-2563eb.svg?style=flat-square)](#tool-reference)
-[![22 APIs](https://img.shields.io/badge/APIs-22-7c3aed.svg?style=flat-square)](#data-sources)
+[![80 Tools](https://img.shields.io/badge/tools-80-2563eb.svg?style=flat-square)](#tool-reference)
+[![23 APIs](https://img.shields.io/badge/APIs-23-7c3aed.svg?style=flat-square)](#data-sources)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776ab.svg?style=flat-square)](https://python.org)
 [![MCP](https://img.shields.io/badge/protocol-MCP-f97316.svg?style=flat-square)](https://modelcontextprotocol.io)
 
-An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **22 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, disaster management, FDA safety data, national parks, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
+An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **23 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, healthcare quality, disaster management, FDA safety data, national parks, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
 
 Built for practical agent workflows: concise high-level tools, raw query access where it matters, and location-aware inputs that accept city names, ZIP codes, addresses, or raw coordinates.
 
-No API keys required for 14 of 22 sources. Install it, point your MCP client at it, and start querying real civic data.
+No API keys required for 15 of 23 sources. Install it, point your MCP client at it, and start querying real civic data.
 
 [Get Started](#get-started) · [What's New](#whats-new) · [Data Sources](#data-sources) · [Tool Reference](#tool-reference) · [Roadmap](#implementation-roadmap) · [Contributing](CONTRIBUTING.md)
 
@@ -57,6 +57,7 @@ python3 -m mcp_govt_api
 
 ## What's New
 
+- Added CMS tools for hospital quality ratings, Medicare provider search, and healthcare data
 - Added FDA tools for recalls, adverse events, and drug labels via openFDA
 - Added CDC public health surveillance tools for disease tracking and vaccination coverage
 - Added shared geolocation support with a new `lookup_location` tool
@@ -96,6 +97,7 @@ python3 -m mcp_govt_api
 
 | Source | What It Covers | Key |
 |--------|---------------|-----|
+| [CMS](https://data.cms.gov) | Hospital quality ratings, Medicare provider search, healthcare data | -- |
 | [FDA (openFDA)](https://open.fda.gov) | Drug/food/device recalls, adverse events, drug labels | -- |
 
 ### Demographics & Economics
@@ -174,6 +176,9 @@ python3 -m mcp_govt_api
 "Show me BLS employment data for 2023"
 "What FEMA disaster declarations were made in Florida this year?"
 "Show me housing assistance data for Hurricane Ian"
+"Search for hospitals in New York with quality ratings"
+"What's the quality rating for facility 050001?"
+"Find Medicare providers specializing in Cardiology in Texas"
 "Show me recent FDA drug recalls in California"
 "What adverse events have been reported for aspirin?"
 "Get drug label information for ibuprofen"
@@ -312,6 +317,17 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 | `get_cdc_disease_surveillance` | Notifiable disease case counts from the NNDSS |
 | `get_cdc_vaccination_coverage` | Vaccination coverage estimates by vaccine and state |
 | `query_cdc_open_data` | Raw CDC SODA API access for any dataset |
+
+</details>
+
+<details>
+<summary><strong>CMS Healthcare</strong> — 3 tools</summary>
+
+| Tool | Description |
+|------|-------------|
+| `search_hospitals` | Search hospitals by name or state with overall quality ratings |
+| `get_hospital_quality` | Get detailed quality measures and ratings for a specific hospital |
+| `search_medicare_providers` | Search Medicare-enrolled healthcare providers by name, state, or specialty |
 
 </details>
 
@@ -478,6 +494,7 @@ API Availability:
   ✓ Space Weather         ✓ NASA FIRMS     ✓ NASA
   ✓ SEC EDGAR             ✓ CDC Open Data
   ✓ BLS                   ✓ FEMA
+  ✓ CMS Healthcare
   ✗ OpenWeather (key not set)
   ✗ EIA (key not set)
 ```
@@ -519,7 +536,6 @@ The active roadmap lives in [#87](https://github.com/EricGrill/mcp-civic-data/is
 - [#71](https://github.com/EricGrill/mcp-civic-data/issues/71) Add NCES education and school district tools
 - [#72](https://github.com/EricGrill/mcp-civic-data/issues/72) Add NHTSA traffic safety and crash statistics tools
 - [#73](https://github.com/EricGrill/mcp-civic-data/issues/73) Add OSHA workplace safety and enforcement tools
-- [#74](https://github.com/EricGrill/mcp-civic-data/issues/74) Add CMS healthcare provider and hospital quality tools
 - [#78](https://github.com/EricGrill/mcp-civic-data/issues/78) Add SBA small business and disaster loan tools
 - [#80](https://github.com/EricGrill/mcp-civic-data/issues/80) Add FDA recalls, shortages, and safety alert tools
 - [#84](https://github.com/EricGrill/mcp-civic-data/issues/84) Add National Park Service parks and alerts tools

--- a/src/mcp_govt_api/server.py
+++ b/src/mcp_govt_api/server.py
@@ -23,6 +23,7 @@ mcp = FastMCP(
 - CISA (cybersecurity advisories, known exploited vulnerabilities)
 - SEC EDGAR (company filings, submissions, and company facts)
 - FRED (Federal Reserve economic data, time series, indicators)
+- CMS (hospital quality ratings, Medicare provider search, healthcare data)
 - CDC (public health surveillance, disease tracking, vaccination coverage)
 - BLS (labor statistics, CPI, unemployment, employment data)
 - FEMA (disaster declarations, disaster summaries, housing assistance)
@@ -46,10 +47,11 @@ from mcp_govt_api.tools import (  # noqa: E402
     cdc,  # noqa: F401
     census,  # noqa: F401
     cisa,  # noqa: F401
+    cms,  # noqa: F401
     datagov,  # noqa: F401
     earthquakes,  # noqa: F401
-    eia,  # noqa: F401
     economics,  # noqa: F401
+    eia,  # noqa: F401
     eu_data,  # noqa: F401
     fda,  # noqa: F401
     fema,  # noqa: F401

--- a/src/mcp_govt_api/tools/cms.py
+++ b/src/mcp_govt_api/tools/cms.py
@@ -1,0 +1,245 @@
+from mcp_govt_api.server import mcp
+from mcp_govt_api.utils.http import fetch_json
+
+CMS_BASE_URL = "https://data.cms.gov/resource"
+
+HOSPITAL_GENERAL_INFO = f"{CMS_BASE_URL}/xubh-q36u.json"
+MEDICARE_PROVIDERS = f"{CMS_BASE_URL}/mj5m-pzi6.json"
+
+
+@mcp.tool()
+async def search_hospitals(
+    name: str = "",
+    state: str = "",
+    limit: int = 10,
+) -> str:
+    """Search hospitals by name or state with overall quality ratings.
+
+    Queries the CMS Hospital General Information dataset for hospitals
+    matching the given name and/or state. Returns hospital name, address,
+    type, ownership, and overall quality rating (1-5 stars).
+
+    Args:
+        name: Hospital name or partial name to search for (case-insensitive)
+        state: Two-letter US state code to filter by (e.g., 'CA', 'NY')
+        limit: Maximum number of results to return (default: 10, max: 100)
+
+    Returns:
+        List of hospitals with name, address, type, ownership, and
+        overall quality rating.
+    """
+    if not name and not state:
+        return "Error: at least one of 'name' or 'state' is required."
+
+    limit = min(max(1, limit), 100)
+
+    where_parts = []
+    if name:
+        where_parts.append(f"upper(hospital_name) like '%{name.upper()}%'")
+    if state:
+        where_parts.append(f"state='{state.upper()}'")
+
+    params = {
+        "$where": " AND ".join(where_parts),
+        "$limit": str(limit),
+        "$order": "hospital_name ASC",
+    }
+
+    try:
+        data = await fetch_json(HOSPITAL_GENERAL_INFO, params=params)
+    except Exception as e:
+        return f"Error fetching hospital data: {e}"
+
+    if not data:
+        return "No hospitals found matching the given criteria."
+
+    lines = [f"CMS Hospital Search Results ({len(data)} hospitals):\n"]
+
+    for h in data:
+        hospital_name = h.get("hospital_name", "N/A")
+        facility_id = h.get("facility_id", "N/A")
+        address = h.get("address", "")
+        city = h.get("city", "")
+        st = h.get("state", "")
+        zip_code = h.get("zip_code", "")
+        full_address = ", ".join(filter(None, [address, city, st, zip_code]))
+        hospital_type = h.get("hospital_type", "N/A")
+        ownership = h.get("hospital_ownership", "N/A")
+        rating = h.get("hospital_overall_rating", "Not Available")
+        phone = h.get("phone_number", "N/A")
+
+        lines.append(f"**{hospital_name}** (ID: {facility_id})")
+        lines.append(f"  Address: {full_address or 'N/A'}")
+        lines.append(f"  Type: {hospital_type}")
+        lines.append(f"  Ownership: {ownership}")
+        lines.append(f"  Overall Rating: {rating} / 5")
+        lines.append(f"  Phone: {phone}")
+        lines.append("")
+
+    lines.append("_Source: CMS Hospital General Information (Hospital Compare)_")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_hospital_quality(
+    facility_id: str,
+) -> str:
+    """Get detailed quality measures and ratings for a specific hospital.
+
+    Retrieves comprehensive hospital quality data from CMS including
+    overall rating, mortality, safety, readmission, patient experience,
+    and timeliness scores for a given facility ID.
+
+    Args:
+        facility_id: CMS facility ID (e.g., '050001'). Use search_hospitals
+            to find facility IDs.
+
+    Returns:
+        Detailed hospital quality information including overall rating,
+        type, ownership, emergency services status, and quality measure
+        footnotes.
+    """
+    if not facility_id:
+        return "Error: facility_id is required."
+
+    params = {
+        "$where": f"facility_id='{facility_id}'",
+        "$limit": "1",
+    }
+
+    try:
+        data = await fetch_json(HOSPITAL_GENERAL_INFO, params=params)
+    except Exception as e:
+        return f"Error fetching hospital quality data: {e}"
+
+    if not data:
+        return f"No hospital found with facility ID '{facility_id}'."
+
+    h = data[0]
+
+    hospital_name = h.get("hospital_name", "N/A")
+    address = h.get("address", "")
+    city = h.get("city", "")
+    st = h.get("state", "")
+    zip_code = h.get("zip_code", "")
+    full_address = ", ".join(filter(None, [address, city, st, zip_code]))
+    hospital_type = h.get("hospital_type", "N/A")
+    ownership = h.get("hospital_ownership", "N/A")
+    emergency = h.get("emergency_services", "N/A")
+    phone = h.get("phone_number", "N/A")
+
+    overall_rating = h.get("hospital_overall_rating", "Not Available")
+    mortality = h.get("mortality_national_comparison", "N/A")
+    safety = h.get("safety_of_care_national_comparison", "N/A")
+    readmission = h.get("readmission_national_comparison", "N/A")
+    patient_exp = h.get("patient_experience_national_comparison", "N/A")
+    effectiveness = h.get("effectiveness_of_care_national_comparison", "N/A")
+    timeliness = h.get("timeliness_of_care_national_comparison", "N/A")
+
+    lines = [
+        f"Hospital Quality Report for {hospital_name} (ID: {facility_id}):\n",
+        f"**{hospital_name}**",
+        f"  Address: {full_address or 'N/A'}",
+        f"  Phone: {phone}",
+        f"  Type: {hospital_type}",
+        f"  Ownership: {ownership}",
+        f"  Emergency Services: {emergency}",
+        "",
+        "Quality Ratings:",
+        f"  Overall Rating: {overall_rating} / 5",
+        f"  Mortality: {mortality}",
+        f"  Safety of Care: {safety}",
+        f"  Readmission: {readmission}",
+        f"  Patient Experience: {patient_exp}",
+        f"  Effectiveness of Care: {effectiveness}",
+        f"  Timeliness of Care: {timeliness}",
+        "",
+        "_Source: CMS Hospital General Information (Hospital Compare)_",
+    ]
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def search_medicare_providers(
+    name: str = "",
+    state: str = "",
+    specialty: str = "",
+    limit: int = 10,
+) -> str:
+    """Search Medicare-enrolled healthcare providers.
+
+    Queries the CMS Medicare provider dataset for providers matching
+    the given name, state, and/or specialty. Returns provider details
+    including name, specialty, address, and enrollment information.
+
+    Args:
+        name: Provider last name or organization name (case-insensitive)
+        state: Two-letter US state code to filter by (e.g., 'CA', 'NY')
+        specialty: Medical specialty to filter by (e.g., 'Internal Medicine',
+            'Cardiology', 'Family Practice')
+        limit: Maximum number of results to return (default: 10, max: 100)
+
+    Returns:
+        List of Medicare providers with name, specialty, address,
+        and enrollment details.
+    """
+    if not name and not state and not specialty:
+        return "Error: at least one of 'name', 'state', or 'specialty' is required."
+
+    limit = min(max(1, limit), 100)
+
+    where_parts = []
+    if name:
+        where_parts.append(f"upper(org_name) like '%{name.upper()}%' OR upper(lst_nm) like '%{name.upper()}%'")
+    if state:
+        where_parts.append(f"st='{state.upper()}'")
+    if specialty:
+        where_parts.append(f"upper(pri_spec) like '%{specialty.upper()}%'")
+
+    params = {
+        "$where": " AND ".join(where_parts),
+        "$limit": str(limit),
+        "$order": "lst_nm ASC",
+    }
+
+    try:
+        data = await fetch_json(MEDICARE_PROVIDERS, params=params)
+    except Exception as e:
+        return f"Error fetching Medicare provider data: {e}"
+
+    if not data:
+        return "No Medicare providers found matching the given criteria."
+
+    lines = [f"CMS Medicare Provider Search Results ({len(data)} providers):\n"]
+
+    for p in data:
+        # Handle individual vs organization
+        org_name = p.get("org_name", "")
+        first_name = p.get("frst_nm", "")
+        last_name = p.get("lst_nm", "")
+        if org_name:
+            display_name = org_name
+        elif first_name or last_name:
+            display_name = f"{first_name} {last_name}".strip()
+        else:
+            display_name = "N/A"
+
+        npi = p.get("npi", "N/A")
+        spec = p.get("pri_spec", "N/A")
+        city = p.get("cty", "")
+        st = p.get("st", "")
+        zip_code = p.get("zip", "")
+        location = ", ".join(filter(None, [city, st, zip_code]))
+        credential = p.get("cred", "")
+
+        lines.append(f"**{display_name}**{f' ({credential})' if credential else ''}")
+        lines.append(f"  NPI: {npi}")
+        lines.append(f"  Specialty: {spec}")
+        lines.append(f"  Location: {location or 'N/A'}")
+        lines.append("")
+
+    lines.append("_Source: CMS Medicare Provider Data_")
+
+    return "\n".join(lines)

--- a/tests/test_cms.py
+++ b/tests/test_cms.py
@@ -1,0 +1,263 @@
+"""Tests for CMS healthcare provider and hospital quality tools."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+
+class TestSearchHospitals(unittest.IsolatedAsyncioTestCase):
+    """Tests for search_hospitals tool."""
+
+    @patch("mcp_govt_api.tools.cms.fetch_json", new_callable=AsyncMock)
+    async def test_search_hospitals_by_name(self, mock_fetch):
+        from mcp_govt_api.tools.cms import search_hospitals
+
+        mock_fetch.return_value = [
+            {
+                "facility_id": "050001",
+                "hospital_name": "GENERAL HOSPITAL",
+                "address": "123 Main St",
+                "city": "Los Angeles",
+                "state": "CA",
+                "zip_code": "90001",
+                "hospital_type": "Acute Care Hospitals",
+                "hospital_ownership": "Government - State",
+                "hospital_overall_rating": "4",
+                "phone_number": "2135551234",
+            }
+        ]
+
+        result = await search_hospitals(name="general", limit=5)
+
+        self.assertIn("GENERAL HOSPITAL", result)
+        self.assertIn("050001", result)
+        self.assertIn("Los Angeles", result)
+        self.assertIn("4 / 5", result)
+        self.assertIn("Acute Care Hospitals", result)
+        mock_fetch.assert_called_once()
+
+    @patch("mcp_govt_api.tools.cms.fetch_json", new_callable=AsyncMock)
+    async def test_search_hospitals_by_state(self, mock_fetch):
+        from mcp_govt_api.tools.cms import search_hospitals
+
+        mock_fetch.return_value = [
+            {
+                "facility_id": "100001",
+                "hospital_name": "FLORIDA MEDICAL CENTER",
+                "address": "456 Oak Ave",
+                "city": "Miami",
+                "state": "FL",
+                "zip_code": "33101",
+                "hospital_type": "Acute Care Hospitals",
+                "hospital_ownership": "Voluntary non-profit - Private",
+                "hospital_overall_rating": "3",
+                "phone_number": "3055559876",
+            }
+        ]
+
+        result = await search_hospitals(state="FL")
+
+        self.assertIn("FLORIDA MEDICAL CENTER", result)
+        self.assertIn("Miami", result)
+
+    @patch("mcp_govt_api.tools.cms.fetch_json", new_callable=AsyncMock)
+    async def test_search_hospitals_no_results(self, mock_fetch):
+        from mcp_govt_api.tools.cms import search_hospitals
+
+        mock_fetch.return_value = []
+
+        result = await search_hospitals(name="nonexistenthospital")
+
+        self.assertIn("No hospitals found", result)
+
+    async def test_search_hospitals_no_params(self):
+        from mcp_govt_api.tools.cms import search_hospitals
+
+        result = await search_hospitals()
+
+        self.assertIn("Error: at least one of", result)
+
+    @patch("mcp_govt_api.tools.cms.fetch_json", new_callable=AsyncMock)
+    async def test_search_hospitals_api_error(self, mock_fetch):
+        from mcp_govt_api.tools.cms import search_hospitals
+
+        mock_fetch.side_effect = Exception("API unavailable")
+
+        result = await search_hospitals(state="CA")
+
+        self.assertIn("Error fetching hospital data", result)
+
+
+class TestGetHospitalQuality(unittest.IsolatedAsyncioTestCase):
+    """Tests for get_hospital_quality tool."""
+
+    @patch("mcp_govt_api.tools.cms.fetch_json", new_callable=AsyncMock)
+    async def test_get_quality_basic(self, mock_fetch):
+        from mcp_govt_api.tools.cms import get_hospital_quality
+
+        mock_fetch.return_value = [
+            {
+                "facility_id": "050001",
+                "hospital_name": "GENERAL HOSPITAL",
+                "address": "123 Main St",
+                "city": "Los Angeles",
+                "state": "CA",
+                "zip_code": "90001",
+                "hospital_type": "Acute Care Hospitals",
+                "hospital_ownership": "Government - State",
+                "emergency_services": "Yes",
+                "phone_number": "2135551234",
+                "hospital_overall_rating": "4",
+                "mortality_national_comparison": "Above the National Average",
+                "safety_of_care_national_comparison": "Same as the National Average",
+                "readmission_national_comparison": "Below the National Average",
+                "patient_experience_national_comparison": "Above the National Average",
+                "effectiveness_of_care_national_comparison": "Same as the National Average",
+                "timeliness_of_care_national_comparison": "Above the National Average",
+            }
+        ]
+
+        result = await get_hospital_quality(facility_id="050001")
+
+        self.assertIn("GENERAL HOSPITAL", result)
+        self.assertIn("4 / 5", result)
+        self.assertIn("Above the National Average", result)
+        self.assertIn("Emergency Services: Yes", result)
+        self.assertIn("Mortality", result)
+        self.assertIn("Safety of Care", result)
+        mock_fetch.assert_called_once()
+
+    @patch("mcp_govt_api.tools.cms.fetch_json", new_callable=AsyncMock)
+    async def test_get_quality_not_found(self, mock_fetch):
+        from mcp_govt_api.tools.cms import get_hospital_quality
+
+        mock_fetch.return_value = []
+
+        result = await get_hospital_quality(facility_id="999999")
+
+        self.assertIn("No hospital found", result)
+
+    async def test_get_quality_empty_id(self):
+        from mcp_govt_api.tools.cms import get_hospital_quality
+
+        result = await get_hospital_quality(facility_id="")
+
+        self.assertIn("Error: facility_id is required", result)
+
+    @patch("mcp_govt_api.tools.cms.fetch_json", new_callable=AsyncMock)
+    async def test_get_quality_api_error(self, mock_fetch):
+        from mcp_govt_api.tools.cms import get_hospital_quality
+
+        mock_fetch.side_effect = Exception("Connection timeout")
+
+        result = await get_hospital_quality(facility_id="050001")
+
+        self.assertIn("Error fetching hospital quality data", result)
+
+
+class TestSearchMedicareProviders(unittest.IsolatedAsyncioTestCase):
+    """Tests for search_medicare_providers tool."""
+
+    @patch("mcp_govt_api.tools.cms.fetch_json", new_callable=AsyncMock)
+    async def test_search_providers_by_name(self, mock_fetch):
+        from mcp_govt_api.tools.cms import search_medicare_providers
+
+        mock_fetch.return_value = [
+            {
+                "npi": "1234567890",
+                "lst_nm": "SMITH",
+                "frst_nm": "JOHN",
+                "org_name": "",
+                "cred": "MD",
+                "pri_spec": "Internal Medicine",
+                "cty": "Chicago",
+                "st": "IL",
+                "zip": "60601",
+            }
+        ]
+
+        result = await search_medicare_providers(name="smith", limit=5)
+
+        self.assertIn("JOHN SMITH", result)
+        self.assertIn("MD", result)
+        self.assertIn("Internal Medicine", result)
+        self.assertIn("1234567890", result)
+        self.assertIn("Chicago", result)
+        mock_fetch.assert_called_once()
+
+    @patch("mcp_govt_api.tools.cms.fetch_json", new_callable=AsyncMock)
+    async def test_search_providers_organization(self, mock_fetch):
+        from mcp_govt_api.tools.cms import search_medicare_providers
+
+        mock_fetch.return_value = [
+            {
+                "npi": "9876543210",
+                "lst_nm": "",
+                "frst_nm": "",
+                "org_name": "CITY MEDICAL GROUP",
+                "cred": "",
+                "pri_spec": "Family Practice",
+                "cty": "New York",
+                "st": "NY",
+                "zip": "10001",
+            }
+        ]
+
+        result = await search_medicare_providers(name="city medical")
+
+        self.assertIn("CITY MEDICAL GROUP", result)
+        self.assertIn("Family Practice", result)
+
+    @patch("mcp_govt_api.tools.cms.fetch_json", new_callable=AsyncMock)
+    async def test_search_providers_by_specialty(self, mock_fetch):
+        from mcp_govt_api.tools.cms import search_medicare_providers
+
+        mock_fetch.return_value = [
+            {
+                "npi": "1111111111",
+                "lst_nm": "DOE",
+                "frst_nm": "JANE",
+                "org_name": "",
+                "cred": "DO",
+                "pri_spec": "Cardiology",
+                "cty": "Houston",
+                "st": "TX",
+                "zip": "77001",
+            }
+        ]
+
+        result = await search_medicare_providers(specialty="Cardiology", state="TX")
+
+        self.assertIn("JANE DOE", result)
+        self.assertIn("Cardiology", result)
+        self.assertIn("Houston", result)
+
+    @patch("mcp_govt_api.tools.cms.fetch_json", new_callable=AsyncMock)
+    async def test_search_providers_no_results(self, mock_fetch):
+        from mcp_govt_api.tools.cms import search_medicare_providers
+
+        mock_fetch.return_value = []
+
+        result = await search_medicare_providers(name="zzzznonexistent")
+
+        self.assertIn("No Medicare providers found", result)
+
+    async def test_search_providers_no_params(self):
+        from mcp_govt_api.tools.cms import search_medicare_providers
+
+        result = await search_medicare_providers()
+
+        self.assertIn("Error: at least one of", result)
+
+    @patch("mcp_govt_api.tools.cms.fetch_json", new_callable=AsyncMock)
+    async def test_search_providers_api_error(self, mock_fetch):
+        from mcp_govt_api.tools.cms import search_medicare_providers
+
+        mock_fetch.side_effect = Exception("Server error")
+
+        result = await search_medicare_providers(state="CA")
+
+        self.assertIn("Error fetching Medicare provider data", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 3 new tools: `search_hospitals`, `get_hospital_quality`, `search_medicare_providers`
- Uses CMS data.cms.gov SODA API, no key required; 15 tests
Closes #74
🤖 Generated with [Claude Code](https://claude.com/claude-code)