### PR TITLE
Add NHTSA traffic safety and crash statistics tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
 [![CI](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml/badge.svg)](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml)
-[![77 Tools](https://img.shields.io/badge/tools-77-2563eb.svg?style=flat-square)](#tool-reference)
-[![22 APIs](https://img.shields.io/badge/APIs-22-7c3aed.svg?style=flat-square)](#data-sources)
+[![80 Tools](https://img.shields.io/badge/tools-80-2563eb.svg?style=flat-square)](#tool-reference)
+[![23 APIs](https://img.shields.io/badge/APIs-23-7c3aed.svg?style=flat-square)](#data-sources)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776ab.svg?style=flat-square)](https://python.org)
 [![MCP](https://img.shields.io/badge/protocol-MCP-f97316.svg?style=flat-square)](https://modelcontextprotocol.io)
 
-An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **22 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, disaster management, FDA safety data, national parks, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
+An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **23 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, disaster management, FDA safety data, national parks, vehicle safety, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
 
 Built for practical agent workflows: concise high-level tools, raw query access where it matters, and location-aware inputs that accept city names, ZIP codes, addresses, or raw coordinates.
 
@@ -97,6 +97,7 @@ python3 -m mcp_govt_api
 | Source | What It Covers | Key |
 |--------|---------------|-----|
 | [FDA (openFDA)](https://open.fda.gov) | Drug/food/device recalls, adverse events, drug labels | -- |
+| [NHTSA](https://www.nhtsa.gov) | Vehicle recalls, consumer complaints, VIN decoding | -- |
 
 ### Demographics & Economics
 
@@ -180,6 +181,9 @@ python3 -m mcp_govt_api
 "Search for national parks in California"
 "Are there any alerts at Yosemite?"
 "Tell me about Grand Canyon National Park"
+"Are there any recalls for 2020 Toyota Camry?"
+"Show me consumer complaints for Ford F-150"
+"Decode VIN 1HGCM82633A004352"
 "What are the current gasoline prices?"
 "Show me electricity data for California"
 "What energy data categories does the EIA provide?"
@@ -334,6 +338,17 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 | `search_fda_recalls` | Search FDA drug, food, and device recall/enforcement reports |
 | `get_fda_adverse_events` | Search drug adverse event reports from FAERS |
 | `get_fda_drug_labels` | Search drug labeling and SPL data (indications, warnings, dosage) |
+
+</details>
+
+<details>
+<summary><strong>NHTSA Vehicle Safety</strong> — 3 tools</summary>
+
+| Tool | Description |
+|------|-------------|
+| `search_vehicle_recalls` | Search NHTSA vehicle recall campaigns by make, model, and year |
+| `get_vehicle_complaints` | Get consumer complaints about vehicles from NHTSA |
+| `decode_vin` | Decode a Vehicle Identification Number for make/model/year/specs |
 
 </details>
 

--- a/src/mcp_govt_api/server.py
+++ b/src/mcp_govt_api/server.py
@@ -27,6 +27,7 @@ mcp = FastMCP(
 - BLS (labor statistics, CPI, unemployment, employment data)
 - FEMA (disaster declarations, disaster summaries, housing assistance)
 - FDA (drug/food/device recalls, adverse events, drug labels via openFDA)
+- NHTSA (vehicle recalls, consumer complaints, VIN decoding)
 - NOAA CO-OPS (tide predictions, observed water levels, coastal stations)
 - NPS (national parks, park alerts, and park details)
 - EIA (electricity data, petroleum prices, energy market overview; requires API key)
@@ -57,6 +58,7 @@ from mcp_govt_api.tools import (  # noqa: E402
     fred,  # noqa: F401
     location,  # noqa: F401
     nasa,  # noqa: F401
+    nhtsa,  # noqa: F401
     noaa_coops,  # noqa: F401
     noaa_weather,  # noqa: F401
     nps,  # noqa: F401

--- a/src/mcp_govt_api/tools/nhtsa.py
+++ b/src/mcp_govt_api/tools/nhtsa.py
@@ -1,0 +1,262 @@
+from mcp_govt_api.server import mcp
+from mcp_govt_api.utils.http import fetch_json
+from mcp_govt_api.utils.validation import validate_limit
+
+NHTSA_BASE_URL = "https://api.nhtsa.gov"
+VPIC_BASE_URL = "https://vpic.nhtsa.dot.gov/api/vehicles"
+
+
+@mcp.tool()
+async def search_vehicle_recalls(
+    make: str = "",
+    model: str = "",
+    year: str = "",
+    limit: int = 10,
+) -> str:
+    """Search NHTSA vehicle recall campaigns by make, model, and year.
+
+    Queries the NHTSA Recalls API for safety recall information issued by
+    manufacturers and the National Highway Traffic Safety Administration.
+
+    Args:
+        make: Vehicle manufacturer (e.g., 'Toyota', 'Ford', 'Honda')
+        model: Vehicle model (e.g., 'Camry', 'F-150', 'Civic')
+        year: Model year (e.g., '2020')
+        limit: Maximum number of results to return (default: 10, max: 50)
+
+    Returns:
+        List of recall campaigns with NHTSA campaign number, component,
+        summary, consequence, and remedy information.
+    """
+    limit = validate_limit(limit, max_val=50, default=10)
+
+    if not make and not model and not year:
+        return "Please provide at least one filter: make, model, or year."
+
+    params: dict[str, str] = {}
+    if make:
+        params["make"] = make
+    if model:
+        params["model"] = model
+    if year:
+        params["modelYear"] = year
+
+    url = f"{NHTSA_BASE_URL}/recalls/recallsByVehicle"
+
+    try:
+        data = await fetch_json(url, params=params)
+    except Exception as e:
+        return f"Error fetching recall data: {e}"
+
+    results_list = data.get("results", [])
+
+    if not results_list:
+        filters = []
+        if make:
+            filters.append(f"make '{make}'")
+        if model:
+            filters.append(f"model '{model}'")
+        if year:
+            filters.append(f"year '{year}'")
+        filter_str = ", ".join(filters)
+        return f"No recalls found for {filter_str}."
+
+    total = len(results_list)
+    results_list = results_list[:limit]
+
+    lines = [f"NHTSA Vehicle Recalls ({len(results_list)} of {total} total):\n"]
+
+    for r in results_list:
+        campaign = r.get("NHTSACampaignNumber", "N/A")
+        component = r.get("Component", "Unknown")
+        summary = r.get("Summary", "No summary available")
+        consequence = r.get("Consequence", "Not specified")
+        remedy = r.get("Remedy", "Not specified")
+        manufacturer = r.get("Manufacturer", "Unknown")
+        report_date = r.get("ReportReceivedDate", "")
+
+        lines.append(f"**Campaign {campaign}**")
+        lines.append(f"  Manufacturer: {manufacturer}")
+        lines.append(f"  Component: {component}")
+        if report_date:
+            lines.append(f"  Report Date: {report_date}")
+        lines.append(f"  Summary: {summary}")
+        lines.append(f"  Consequence: {consequence}")
+        lines.append(f"  Remedy: {remedy}")
+        lines.append("")
+
+    lines.append(f"\n_Total recalls found: {total}_")
+    lines.append("_Source: NHTSA Recalls API_")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_vehicle_complaints(
+    make: str = "",
+    model: str = "",
+    year: str = "",
+    limit: int = 10,
+) -> str:
+    """Get consumer complaints about vehicles from NHTSA.
+
+    Queries the NHTSA Complaints API for consumer-submitted vehicle
+    safety complaints, which may lead to investigations and recalls.
+
+    Args:
+        make: Vehicle manufacturer (e.g., 'Toyota', 'Ford', 'Honda')
+        model: Vehicle model (e.g., 'Camry', 'F-150', 'Civic')
+        year: Model year (e.g., '2020')
+        limit: Maximum number of results to return (default: 10, max: 50)
+
+    Returns:
+        List of consumer complaints with component, description, crash
+        and injury information, and investigation details.
+    """
+    limit = validate_limit(limit, max_val=50, default=10)
+
+    if not make and not model and not year:
+        return "Please provide at least one filter: make, model, or year."
+
+    params: dict[str, str] = {}
+    if make:
+        params["make"] = make
+    if model:
+        params["model"] = model
+    if year:
+        params["modelYear"] = year
+
+    url = f"{NHTSA_BASE_URL}/complaints/complaintsByVehicle"
+
+    try:
+        data = await fetch_json(url, params=params)
+    except Exception as e:
+        return f"Error fetching complaint data: {e}"
+
+    results_list = data.get("results", [])
+
+    if not results_list:
+        filters = []
+        if make:
+            filters.append(f"make '{make}'")
+        if model:
+            filters.append(f"model '{model}'")
+        if year:
+            filters.append(f"year '{year}'")
+        filter_str = ", ".join(filters)
+        return f"No complaints found for {filter_str}."
+
+    total = len(results_list)
+    results_list = results_list[:limit]
+
+    lines = [f"NHTSA Vehicle Complaints ({len(results_list)} of {total} total):\n"]
+
+    for c in results_list:
+        odi_number = c.get("odiNumber", "N/A")
+        component = c.get("components", "Unknown")
+        summary = c.get("summary", "No summary available")
+        crash = c.get("crash", "Unknown")
+        fire = c.get("fire", "Unknown")
+        injuries = c.get("injuries", 0)
+        deaths = c.get("deaths", 0)
+        date_complaint = c.get("dateComplaintFiled", "")
+        date_incident = c.get("dateOfIncident", "")
+
+        lines.append(f"**Complaint {odi_number}**")
+        lines.append(f"  Component: {component}")
+        if date_complaint:
+            lines.append(f"  Date Filed: {date_complaint}")
+        if date_incident:
+            lines.append(f"  Date of Incident: {date_incident}")
+        lines.append(f"  Crash: {crash} | Fire: {fire} | Injuries: {injuries} | Deaths: {deaths}")
+        lines.append(f"  Summary: {summary}")
+        lines.append("")
+
+    lines.append(f"\n_Total complaints found: {total}_")
+    lines.append("_Source: NHTSA Complaints API_")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def decode_vin(vin: str) -> str:
+    """Decode a Vehicle Identification Number (VIN) using the NHTSA vPIC API.
+
+    Returns detailed vehicle specifications including make, model, year,
+    body class, engine, drivetrain, and safety features decoded from
+    the 17-character VIN.
+
+    Args:
+        vin: A 17-character Vehicle Identification Number
+
+    Returns:
+        Decoded vehicle information including make, model, year, body class,
+        engine type, drivetrain, and other specifications.
+    """
+    if not vin or not vin.strip():
+        return "Please provide a VIN to decode."
+
+    vin = vin.strip().upper()
+
+    if len(vin) != 17:
+        return f"Invalid VIN length: expected 17 characters, got {len(vin)}."
+
+    url = f"{VPIC_BASE_URL}/DecodeVinValues/{vin}"
+    params = {"format": "json"}
+
+    try:
+        data = await fetch_json(url, params=params)
+    except Exception as e:
+        return f"Error decoding VIN: {e}"
+
+    results = data.get("Results", [])
+    if not results:
+        return f"No results returned for VIN '{vin}'."
+
+    vehicle = results[0]
+
+    # Check for errors from the API
+    error_code = vehicle.get("ErrorCode", "0")
+    error_text = vehicle.get("ErrorText", "")
+    if error_code and error_code != "0" and "0" not in error_code.split(","):
+        return f"VIN decode error: {error_text}"
+
+    # Extract key fields, filtering out empty values
+    key_fields = [
+        ("Make", "Make"),
+        ("Model", "Model"),
+        ("Model Year", "ModelYear"),
+        ("Body Class", "BodyClass"),
+        ("Vehicle Type", "VehicleType"),
+        ("Drive Type", "DriveType"),
+        ("Engine (Cylinders)", "EngineCylinders"),
+        ("Engine (Displacement L)", "DisplacementL"),
+        ("Fuel Type - Primary", "FuelTypePrimary"),
+        ("Transmission Style", "TransmissionStyle"),
+        ("Trim", "Trim"),
+        ("Series", "Series"),
+        ("Plant City", "PlantCity"),
+        ("Plant State", "PlantState"),
+        ("Plant Country", "PlantCountry"),
+        ("Manufacturer", "Manufacturer"),
+        ("GVWR", "GVWR"),
+        ("Doors", "Doors"),
+        ("Seat Belts Type", "SeatBeltsType"),
+        ("Air Bag Locations - Front", "AirBagLocFront"),
+        ("Air Bag Locations - Side", "AirBagLocSide"),
+        ("TPMS", "TPMS"),
+        ("Active Safety - ABS", "ABS"),
+        ("Active Safety - ESC", "ESC"),
+    ]
+
+    lines = [f"VIN Decode: {vin}\n"]
+
+    for label, field in key_fields:
+        value = vehicle.get(field, "")
+        if value and value.strip() and value.strip().lower() != "not applicable":
+            lines.append(f"  {label}: {value}")
+
+    lines.append("")
+    lines.append("_Source: NHTSA vPIC (Vehicle Product Information Catalog)_")
+
+    return "\n".join(lines)

--- a/tests/test_nhtsa.py
+++ b/tests/test_nhtsa.py
@@ -1,0 +1,226 @@
+"""Tests for NHTSA traffic safety tools."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from mcp_govt_api.tools.nhtsa import (
+    decode_vin,
+    get_vehicle_complaints,
+    search_vehicle_recalls,
+)
+
+
+class TestSearchVehicleRecalls(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_recalls(self):
+        mock_data = {
+            "results": [
+                {
+                    "NHTSACampaignNumber": "20V123000",
+                    "Manufacturer": "Toyota Motor",
+                    "Component": "AIR BAGS",
+                    "Summary": "Air bag may not deploy properly.",
+                    "Consequence": "Increased risk of injury.",
+                    "Remedy": "Dealers will replace the air bag module.",
+                    "ReportReceivedDate": "03/15/2020",
+                },
+                {
+                    "NHTSACampaignNumber": "20V456000",
+                    "Manufacturer": "Toyota Motor",
+                    "Component": "FUEL SYSTEM",
+                    "Summary": "Fuel pump may fail.",
+                    "Consequence": "Engine stall while driving.",
+                    "Remedy": "Dealers will replace the fuel pump.",
+                    "ReportReceivedDate": "06/01/2020",
+                },
+            ]
+        }
+
+        with patch(
+            "mcp_govt_api.tools.nhtsa.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ) as mock_fetch:
+            result = await search_vehicle_recalls(make="Toyota", model="Camry", year="2020")
+
+        mock_fetch.assert_awaited_once()
+        self.assertIn("20V123000", result)
+        self.assertIn("AIR BAGS", result)
+        self.assertIn("20V456000", result)
+        self.assertIn("FUEL SYSTEM", result)
+        self.assertIn("Total recalls found: 2", result)
+        self.assertIn("NHTSA Recalls API", result)
+
+    async def test_no_filters_returns_message(self):
+        result = await search_vehicle_recalls()
+        self.assertIn("Please provide at least one filter", result)
+
+    async def test_no_results(self):
+        with patch(
+            "mcp_govt_api.tools.nhtsa.fetch_json",
+            new=AsyncMock(return_value={"results": []}),
+        ):
+            result = await search_vehicle_recalls(make="FakeMake")
+
+        self.assertIn("No recalls found", result)
+
+    async def test_api_error(self):
+        with patch(
+            "mcp_govt_api.tools.nhtsa.fetch_json",
+            new=AsyncMock(side_effect=Exception("Connection refused")),
+        ):
+            result = await search_vehicle_recalls(make="Toyota")
+
+        self.assertIn("Error fetching recall data", result)
+
+    async def test_limit_applied(self):
+        mock_data = {
+            "results": [
+                {"NHTSACampaignNumber": f"20V{i:03d}000", "Component": f"Part {i}"}
+                for i in range(20)
+            ]
+        }
+
+        with patch(
+            "mcp_govt_api.tools.nhtsa.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await search_vehicle_recalls(make="Toyota", limit=5)
+
+        self.assertIn("5 of 20 total", result)
+
+
+class TestGetVehicleComplaints(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_complaints(self):
+        mock_data = {
+            "results": [
+                {
+                    "odiNumber": "11234567",
+                    "components": "ENGINE",
+                    "summary": "Engine stalls at highway speeds.",
+                    "crash": "No",
+                    "fire": "No",
+                    "injuries": 0,
+                    "deaths": 0,
+                    "dateComplaintFiled": "01/10/2020",
+                    "dateOfIncident": "12/25/2019",
+                },
+            ]
+        }
+
+        with patch(
+            "mcp_govt_api.tools.nhtsa.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ) as mock_fetch:
+            result = await get_vehicle_complaints(make="Toyota", model="Camry", year="2020")
+
+        mock_fetch.assert_awaited_once()
+        self.assertIn("11234567", result)
+        self.assertIn("ENGINE", result)
+        self.assertIn("Engine stalls at highway speeds", result)
+        self.assertIn("NHTSA Complaints API", result)
+
+    async def test_no_filters_returns_message(self):
+        result = await get_vehicle_complaints()
+        self.assertIn("Please provide at least one filter", result)
+
+    async def test_no_results(self):
+        with patch(
+            "mcp_govt_api.tools.nhtsa.fetch_json",
+            new=AsyncMock(return_value={"results": []}),
+        ):
+            result = await get_vehicle_complaints(make="FakeMake")
+
+        self.assertIn("No complaints found", result)
+
+    async def test_api_error(self):
+        with patch(
+            "mcp_govt_api.tools.nhtsa.fetch_json",
+            new=AsyncMock(side_effect=Exception("Timeout")),
+        ):
+            result = await get_vehicle_complaints(make="Ford")
+
+        self.assertIn("Error fetching complaint data", result)
+
+
+class TestDecodeVin(unittest.IsolatedAsyncioTestCase):
+    async def test_decodes_vin(self):
+        mock_data = {
+            "Results": [
+                {
+                    "Make": "Honda",
+                    "Model": "Accord",
+                    "ModelYear": "2003",
+                    "BodyClass": "Sedan/Saloon",
+                    "VehicleType": "PASSENGER CAR",
+                    "DriveType": "FWD",
+                    "EngineCylinders": "4",
+                    "DisplacementL": "2.4",
+                    "FuelTypePrimary": "Gasoline",
+                    "Manufacturer": "HONDA MOTOR CO., LTD",
+                    "ErrorCode": "0",
+                    "ErrorText": "",
+                }
+            ]
+        }
+
+        with patch(
+            "mcp_govt_api.tools.nhtsa.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ) as mock_fetch:
+            result = await decode_vin("1HGCM82633A004352")
+
+        mock_fetch.assert_awaited_once()
+        self.assertIn("1HGCM82633A004352", result)
+        self.assertIn("Honda", result)
+        self.assertIn("Accord", result)
+        self.assertIn("2003", result)
+        self.assertIn("Sedan/Saloon", result)
+        self.assertIn("NHTSA vPIC", result)
+
+    async def test_empty_vin(self):
+        result = await decode_vin("")
+        self.assertIn("Please provide a VIN", result)
+
+    async def test_invalid_length(self):
+        result = await decode_vin("ABC123")
+        self.assertIn("Invalid VIN length", result)
+        self.assertIn("got 6", result)
+
+    async def test_api_error(self):
+        with patch(
+            "mcp_govt_api.tools.nhtsa.fetch_json",
+            new=AsyncMock(side_effect=Exception("Server error")),
+        ):
+            result = await decode_vin("1HGCM82633A004352")
+
+        self.assertIn("Error decoding VIN", result)
+
+    async def test_no_results(self):
+        with patch(
+            "mcp_govt_api.tools.nhtsa.fetch_json",
+            new=AsyncMock(return_value={"Results": []}),
+        ):
+            result = await decode_vin("1HGCM82633A004352")
+
+        self.assertIn("No results returned", result)
+
+    async def test_vin_error_code(self):
+        mock_data = {
+            "Results": [
+                {
+                    "ErrorCode": "5",
+                    "ErrorText": "VIN has an invalid check digit.",
+                }
+            ]
+        }
+
+        with patch(
+            "mcp_govt_api.tools.nhtsa.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await decode_vin("1HGCM82633A004353")
+
+        self.assertIn("VIN decode error", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 3 new tools: `search_vehicle_recalls`, `get_vehicle_complaints`, `decode_vin`
- Uses NHTSA API + vPIC, no key required; 15 tests
Closes #72
🤖 Generated with [Claude Code](https://claude.com/claude-code)