### PR TITLE
Add SAMHSA mental health and treatment facility tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
 [![CI](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml/badge.svg)](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml)
-[![77 Tools](https://img.shields.io/badge/tools-77-2563eb.svg?style=flat-square)](#tool-reference)
-[![22 APIs](https://img.shields.io/badge/APIs-22-7c3aed.svg?style=flat-square)](#data-sources)
+[![80 Tools](https://img.shields.io/badge/tools-80-2563eb.svg?style=flat-square)](#tool-reference)
+[![23 APIs](https://img.shields.io/badge/APIs-23-7c3aed.svg?style=flat-square)](#data-sources)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776ab.svg?style=flat-square)](https://python.org)
 [![MCP](https://img.shields.io/badge/protocol-MCP-f97316.svg?style=flat-square)](https://modelcontextprotocol.io)
 
-An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **22 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, disaster management, FDA safety data, national parks, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
+An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **23 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, behavioral health, disaster management, FDA safety data, national parks, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
 
 Built for practical agent workflows: concise high-level tools, raw query access where it matters, and location-aware inputs that accept city names, ZIP codes, addresses, or raw coordinates.
 
-No API keys required for 14 of 22 sources. Install it, point your MCP client at it, and start querying real civic data.
+No API keys required for 15 of 23 sources. Install it, point your MCP client at it, and start querying real civic data.
 
 [Get Started](#get-started) · [What's New](#whats-new) · [Data Sources](#data-sources) · [Tool Reference](#tool-reference) · [Roadmap](#implementation-roadmap) · [Contributing](CONTRIBUTING.md)
 
@@ -57,6 +57,7 @@ python3 -m mcp_govt_api
 
 ## What's New
 
+- Added SAMHSA tools for mental health and substance abuse treatment facility locator and behavioral health data
 - Added FDA tools for recalls, adverse events, and drug labels via openFDA
 - Added CDC public health surveillance tools for disease tracking and vaccination coverage
 - Added shared geolocation support with a new `lookup_location` tool
@@ -97,6 +98,7 @@ python3 -m mcp_govt_api
 | Source | What It Covers | Key |
 |--------|---------------|-----|
 | [FDA (openFDA)](https://open.fda.gov) | Drug/food/device recalls, adverse events, drug labels | -- |
+| [SAMHSA](https://findtreatment.gov) | Mental health and substance abuse treatment facilities, behavioral health data | -- |
 
 ### Demographics & Economics
 
@@ -183,6 +185,8 @@ python3 -m mcp_govt_api
 "What are the current gasoline prices?"
 "Show me electricity data for California"
 "What energy data categories does the EIA provide?"
+"Find mental health treatment facilities near Chicago"
+"Search SAMHSA data for opioid treatment admissions"
 ```
 
 ---
@@ -338,6 +342,17 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 </details>
 
 <details>
+<summary><strong>SAMHSA (Behavioral Health)</strong> — 3 tools</summary>
+
+| Tool | Description |
+|------|-------------|
+| `find_treatment_facilities` | Find mental health and substance abuse treatment facilities near a location |
+| `search_samhsa_datasets` | Search SAMHSA open data catalog for behavioral health datasets |
+| `get_samhsa_facility_details` | Get detailed info about a specific SAMHSA treatment facility |
+
+</details>
+
+<details>
 <summary><strong>SEC EDGAR</strong> — 5 tools</summary>
 
 | Tool | Description |
@@ -477,7 +492,7 @@ API Availability:
   ✓ Safecast              ✓ Data.gov       ✓ EU Open Data
   ✓ Space Weather         ✓ NASA FIRMS     ✓ NASA
   ✓ SEC EDGAR             ✓ CDC Open Data
-  ✓ BLS                   ✓ FEMA
+  ✓ BLS                   ✓ FEMA           ✓ SAMHSA
   ✗ OpenWeather (key not set)
   ✗ EIA (key not set)
 ```

--- a/src/mcp_govt_api/server.py
+++ b/src/mcp_govt_api/server.py
@@ -30,6 +30,7 @@ mcp = FastMCP(
 - NOAA CO-OPS (tide predictions, observed water levels, coastal stations)
 - NPS (national parks, park alerts, and park details)
 - EIA (electricity data, petroleum prices, energy market overview; requires API key)
+- SAMHSA (mental health and substance abuse treatment facility locator, behavioral health data)
 """,
 )
 
@@ -62,6 +63,7 @@ from mcp_govt_api.tools import (  # noqa: E402
     nps,  # noqa: F401
     openaq,  # noqa: F401
     safecast,  # noqa: F401
+    samhsa,  # noqa: F401
     sec,  # noqa: F401
     space_weather,  # noqa: F401
     usgs_water,  # noqa: F401

--- a/src/mcp_govt_api/tools/samhsa.py
+++ b/src/mcp_govt_api/tools/samhsa.py
@@ -1,0 +1,251 @@
+from mcp_govt_api.server import mcp
+from mcp_govt_api.utils.http import fetch_json
+
+LOCATOR_BASE_URL = "https://findtreatment.gov/locator"
+DATA_BASE_URL = "https://data.samhsa.gov/resource"
+
+
+@mcp.tool()
+async def find_treatment_facilities(
+    location: str,
+    service_type: str = "BOTH",
+    limit: int = 10,
+) -> str:
+    """Find SAMHSA treatment facilities near a location.
+
+    Searches the SAMHSA treatment locator for substance abuse and mental
+    health treatment facilities across the United States.
+
+    Args:
+        location: Location to search near (city/state, ZIP code, or address)
+        service_type: Type of service - 'SA' (substance abuse),
+            'MH' (mental health), or 'BOTH' (default: 'BOTH')
+        limit: Maximum number of results to return (default: 10, max: 50)
+
+    Returns:
+        List of treatment facilities with name, address, phone,
+        services offered, and accepted payment types.
+    """
+    limit = min(limit, 50)
+    service_type = service_type.upper()
+    if service_type not in ("SA", "MH", "BOTH"):
+        return "Error: service_type must be 'SA' (substance abuse), 'MH' (mental health), or 'BOTH'."
+
+    params: dict = {
+        "sAddr": location,
+        "sType": service_type,
+        "limitValue": limit,
+        "pageSize": limit,
+    }
+
+    url = f"{LOCATOR_BASE_URL}/listing"
+
+    try:
+        data = await fetch_json(url, params=params)
+    except Exception as e:
+        return f"Error fetching SAMHSA treatment facilities: {e}"
+
+    rows = data if isinstance(data, list) else data.get("rows", data.get("results", []))
+
+    if not rows:
+        return f"No SAMHSA treatment facilities found near '{location}' for service type '{service_type}'."
+
+    lines = [f"SAMHSA Treatment Facilities near '{location}' ({len(rows)} result(s)):\n"]
+
+    for r in rows:
+        name = r.get("name1", r.get("name", "Unknown"))
+        street = r.get("street1", r.get("street", ""))
+        city = r.get("city", "")
+        state = r.get("state", "")
+        zip_code = r.get("zip", r.get("zip5", ""))
+        phone = r.get("phone", "")
+        services = r.get("services", r.get("typeFacility", ""))
+        payment = r.get("payment", "")
+
+        lines.append(f"**{name}**")
+        address_parts = [p for p in [street, city, state, zip_code] if p]
+        if address_parts:
+            lines.append(f"  Address: {', '.join(address_parts)}")
+        if phone:
+            lines.append(f"  Phone: {phone}")
+        if services:
+            if isinstance(services, list):
+                services = ", ".join(services)
+            lines.append(f"  Services: {services}")
+        if payment:
+            if isinstance(payment, list):
+                payment = ", ".join(payment)
+            lines.append(f"  Payment: {payment}")
+        lines.append("")
+
+    lines.append("_Source: SAMHSA Treatment Locator (findtreatment.gov)_")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def search_samhsa_datasets(
+    query: str = "",
+    limit: int = 10,
+) -> str:
+    """Search SAMHSA open data catalog for behavioral health datasets.
+
+    Queries the SAMHSA data portal (data.samhsa.gov) for datasets
+    related to mental health, substance abuse, and behavioral health.
+
+    Args:
+        query: Search keywords (e.g., 'opioid', 'mental health',
+            'substance abuse', 'treatment admissions')
+        limit: Maximum number of results to return (default: 10, max: 50)
+
+    Returns:
+        List of matching datasets with name, description, and data link.
+    """
+    limit = min(limit, 50)
+
+    params: dict = {
+        "limit": limit,
+    }
+    if query:
+        params["q"] = query
+
+    url = "https://data.samhsa.gov/api/views/metadata/v1"
+
+    try:
+        data = await fetch_json(url, params=params)
+    except Exception as e:
+        return f"Error searching SAMHSA datasets: {e}"
+
+    records = data if isinstance(data, list) else []
+
+    if not records:
+        search_desc = f"query '{query}'" if query else "all datasets"
+        return f"No SAMHSA datasets found for {search_desc}."
+
+    # Limit results
+    records = records[:limit]
+
+    lines = [f"SAMHSA Open Data Catalog ({len(records)} result(s)):\n"]
+
+    for r in records:
+        name = r.get("name", "Unknown")
+        description = r.get("description", "No description available")
+        dataset_id = r.get("id", "")
+        category = r.get("category", "")
+        updated = r.get("dataUpdatedAt", r.get("updatedAt", ""))
+
+        # Truncate long descriptions
+        if len(description) > 200:
+            description = description[:200] + "..."
+
+        lines.append(f"**{name}**")
+        if dataset_id:
+            lines.append(f"  ID: {dataset_id}")
+            lines.append(f"  URL: https://data.samhsa.gov/resource/{dataset_id}")
+        if category:
+            lines.append(f"  Category: {category}")
+        if updated and len(updated) >= 10:
+            lines.append(f"  Updated: {updated[:10]}")
+        lines.append(f"  Description: {description}")
+        lines.append("")
+
+    lines.append("_Source: SAMHSA Open Data Portal (data.samhsa.gov)_")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_samhsa_facility_details(
+    facility_id: str,
+) -> str:
+    """Get detailed information about a SAMHSA treatment facility.
+
+    Retrieves comprehensive details about a specific treatment facility
+    from the SAMHSA treatment locator, including services offered,
+    payment options, special programs, and certifications.
+
+    Args:
+        facility_id: The facility identifier (from find_treatment_facilities results)
+
+    Returns:
+        Detailed facility information including services, payment options,
+        special programs, languages, and certifications.
+    """
+    if not facility_id:
+        return "Error: facility_id is required. Use find_treatment_facilities to discover facility IDs."
+
+    url = f"{LOCATOR_BASE_URL}/detail/{facility_id}"
+
+    try:
+        data = await fetch_json(url)
+    except Exception as e:
+        return f"Error fetching SAMHSA facility details: {e}"
+
+    if not data:
+        return f"No SAMHSA facility found with ID '{facility_id}'."
+
+    name = data.get("name1", data.get("name", "Unknown"))
+    street = data.get("street1", data.get("street", ""))
+    city = data.get("city", "")
+    state = data.get("state", "")
+    zip_code = data.get("zip", data.get("zip5", ""))
+    phone = data.get("phone", "")
+    website = data.get("website", "")
+    services = data.get("services", [])
+    payment = data.get("payment", [])
+    languages = data.get("languages", [])
+    special_programs = data.get("specialPrograms", data.get("special_programs", []))
+    intake_process = data.get("intakeProcess", "")
+    hours = data.get("hours", "")
+
+    lines = [f"SAMHSA Facility Details - {name}\n"]
+
+    address_parts = [p for p in [street, city, state, zip_code] if p]
+    if address_parts:
+        lines.append(f"**Address:** {', '.join(address_parts)}")
+    if phone:
+        lines.append(f"**Phone:** {phone}")
+    if website:
+        lines.append(f"**Website:** {website}")
+    if hours:
+        lines.append(f"**Hours:** {hours}")
+
+    lines.append("")
+
+    if services:
+        if isinstance(services, list):
+            lines.append("**Services:**")
+            for s in services:
+                lines.append(f"  - {s}")
+        else:
+            lines.append(f"**Services:** {services}")
+
+    if payment:
+        if isinstance(payment, list):
+            lines.append("**Payment Options:**")
+            for p in payment:
+                lines.append(f"  - {p}")
+        else:
+            lines.append(f"**Payment Options:** {payment}")
+
+    if special_programs:
+        if isinstance(special_programs, list):
+            lines.append("**Special Programs:**")
+            for sp in special_programs:
+                lines.append(f"  - {sp}")
+        else:
+            lines.append(f"**Special Programs:** {special_programs}")
+
+    if languages:
+        if isinstance(languages, list):
+            lines.append(f"**Languages:** {', '.join(languages)}")
+        else:
+            lines.append(f"**Languages:** {languages}")
+
+    if intake_process:
+        lines.append(f"**Intake Process:** {intake_process}")
+
+    lines.append("")
+    lines.append("_Source: SAMHSA Treatment Locator (findtreatment.gov)_")
+
+    return "\n".join(lines)

--- a/tests/test_samhsa.py
+++ b/tests/test_samhsa.py
@@ -1,0 +1,235 @@
+"""Tests for SAMHSA mental health and treatment facility tools."""
+
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from mcp_govt_api.tools.samhsa import (
+    find_treatment_facilities,
+    get_samhsa_facility_details,
+    search_samhsa_datasets,
+)
+
+
+class TestFindTreatmentFacilities(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_facilities(self):
+        mock_data = {
+            "rows": [
+                {
+                    "name1": "Recovery Center of Hope",
+                    "street1": "123 Main St",
+                    "city": "Springfield",
+                    "state": "IL",
+                    "zip": "62704",
+                    "phone": "217-555-0100",
+                    "services": ["Substance abuse treatment", "Mental health services"],
+                    "payment": ["Medicaid", "Private insurance"],
+                },
+            ]
+        }
+
+        with patch(
+            "mcp_govt_api.tools.samhsa.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await find_treatment_facilities(location="Springfield, IL")
+
+        self.assertIn("Recovery Center of Hope", result)
+        self.assertIn("123 Main St", result)
+        self.assertIn("Springfield", result)
+        self.assertIn("217-555-0100", result)
+        self.assertIn("Substance abuse treatment", result)
+        self.assertIn("Medicaid", result)
+
+    async def test_returns_facilities_from_list(self):
+        mock_data = [
+            {
+                "name1": "Metro Behavioral Health",
+                "street1": "456 Oak Ave",
+                "city": "Chicago",
+                "state": "IL",
+                "zip": "60601",
+                "phone": "312-555-0200",
+            },
+        ]
+
+        with patch(
+            "mcp_govt_api.tools.samhsa.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await find_treatment_facilities(
+                location="Chicago, IL", service_type="MH"
+            )
+
+        self.assertIn("Metro Behavioral Health", result)
+        self.assertIn("Chicago", result)
+
+    async def test_empty_results(self):
+        mock_data = {"rows": []}
+
+        with patch(
+            "mcp_govt_api.tools.samhsa.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await find_treatment_facilities(location="Middle of Nowhere")
+
+        self.assertIn("No SAMHSA treatment facilities found", result)
+        self.assertIn("Middle of Nowhere", result)
+
+    async def test_invalid_service_type(self):
+        result = await find_treatment_facilities(
+            location="Chicago", service_type="INVALID"
+        )
+        self.assertIn("Error", result)
+        self.assertIn("service_type", result)
+
+    async def test_handles_api_error(self):
+        with patch(
+            "mcp_govt_api.tools.samhsa.fetch_json",
+            new=AsyncMock(side_effect=Exception("Connection refused")),
+        ):
+            result = await find_treatment_facilities(location="New York")
+
+        self.assertIn("Error fetching SAMHSA treatment facilities", result)
+        self.assertIn("Connection refused", result)
+
+    async def test_limit_capped_at_50(self):
+        mock_data = {"rows": []}
+
+        with patch(
+            "mcp_govt_api.tools.samhsa.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ) as mock_fetch:
+            await find_treatment_facilities(location="LA", limit=100)
+
+        call_args = mock_fetch.call_args
+        params = call_args[1].get("params") or call_args[0][1]
+        self.assertEqual(params["limitValue"], 50)
+
+
+class TestSearchSamhsaDatasets(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_datasets(self):
+        mock_data = [
+            {
+                "name": "Treatment Episode Data Set",
+                "id": "abcd-1234",
+                "description": "Annual data on admissions to substance abuse treatment.",
+                "category": "Substance Abuse",
+                "dataUpdatedAt": "2024-06-15T00:00:00.000Z",
+            },
+        ]
+
+        with patch(
+            "mcp_govt_api.tools.samhsa.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await search_samhsa_datasets(query="treatment admissions")
+
+        self.assertIn("Treatment Episode Data Set", result)
+        self.assertIn("abcd-1234", result)
+        self.assertIn("Substance Abuse", result)
+        self.assertIn("2024-06-15", result)
+        self.assertIn("data.samhsa.gov/resource/abcd-1234", result)
+
+    async def test_empty_results(self):
+        mock_data = []
+
+        with patch(
+            "mcp_govt_api.tools.samhsa.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await search_samhsa_datasets(query="nonexistent")
+
+        self.assertIn("No SAMHSA datasets found", result)
+
+    async def test_handles_api_error(self):
+        with patch(
+            "mcp_govt_api.tools.samhsa.fetch_json",
+            new=AsyncMock(side_effect=Exception("Timeout")),
+        ):
+            result = await search_samhsa_datasets(query="opioid")
+
+        self.assertIn("Error searching SAMHSA datasets", result)
+        self.assertIn("Timeout", result)
+
+    async def test_truncates_long_descriptions(self):
+        mock_data = [
+            {
+                "name": "Long Dataset",
+                "id": "wxyz-5678",
+                "description": "A" * 300,
+            },
+        ]
+
+        with patch(
+            "mcp_govt_api.tools.samhsa.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await search_samhsa_datasets(query="test")
+
+        self.assertIn("...", result)
+
+
+class TestGetSamhsaFacilityDetails(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_facility_details(self):
+        mock_data = {
+            "name1": "Hope Treatment Center",
+            "street1": "789 Elm St",
+            "city": "Austin",
+            "state": "TX",
+            "zip": "73301",
+            "phone": "512-555-0300",
+            "website": "https://hopetreatment.example.com",
+            "services": ["Outpatient", "Residential"],
+            "payment": ["Medicaid", "Medicare", "Sliding scale"],
+            "languages": ["English", "Spanish"],
+            "specialPrograms": ["Veterans", "Adolescents"],
+            "hours": "Mon-Fri 8am-6pm",
+            "intakeProcess": "Walk-in and phone appointments accepted",
+        }
+
+        with patch(
+            "mcp_govt_api.tools.samhsa.fetch_json",
+            new=AsyncMock(return_value=mock_data),
+        ):
+            result = await get_samhsa_facility_details(facility_id="12345")
+
+        self.assertIn("Hope Treatment Center", result)
+        self.assertIn("789 Elm St", result)
+        self.assertIn("Austin", result)
+        self.assertIn("512-555-0300", result)
+        self.assertIn("hopetreatment.example.com", result)
+        self.assertIn("Outpatient", result)
+        self.assertIn("Medicaid", result)
+        self.assertIn("Spanish", result)
+        self.assertIn("Veterans", result)
+        self.assertIn("Mon-Fri", result)
+        self.assertIn("Walk-in", result)
+
+    async def test_missing_facility_id(self):
+        result = await get_samhsa_facility_details(facility_id="")
+        self.assertIn("Error", result)
+        self.assertIn("facility_id is required", result)
+
+    async def test_not_found(self):
+        with patch(
+            "mcp_govt_api.tools.samhsa.fetch_json",
+            new=AsyncMock(return_value={}),
+        ):
+            result = await get_samhsa_facility_details(facility_id="99999")
+
+        self.assertIn("No SAMHSA facility found", result)
+        self.assertIn("99999", result)
+
+    async def test_handles_api_error(self):
+        with patch(
+            "mcp_govt_api.tools.samhsa.fetch_json",
+            new=AsyncMock(side_effect=Exception("Not found")),
+        ):
+            result = await get_samhsa_facility_details(facility_id="12345")
+
+        self.assertIn("Error fetching SAMHSA facility details", result)
+        self.assertIn("Not found", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 3 new tools: `find_treatment_facilities`, `search_samhsa_datasets`, `get_samhsa_facility_details`
- Uses findtreatment.gov + data.samhsa.gov, no key required; 14 tests
Closes #68
🤖 Generated with [Claude Code](https://claude.com/claude-code)