### PR TITLE
Add USDA food and agriculture data tools

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,10 @@
 # Get a free key at https://www.eia.gov/opendata/register.php
 # EIA_API_KEY=your_eia_api_key
 
+# USDA API (required for food nutrition and crop data tools)
+# Get a free key at https://fdc.nal.usda.gov/api-key-signup.html
+# USDA_API_KEY=your_usda_api_key
+
 # API Timeout (seconds)
 API_TIMEOUT=30
 

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
 [![CI](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml/badge.svg)](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml)
-[![77 Tools](https://img.shields.io/badge/tools-77-2563eb.svg?style=flat-square)](#tool-reference)
-[![22 APIs](https://img.shields.io/badge/APIs-22-7c3aed.svg?style=flat-square)](#data-sources)
+[![80 Tools](https://img.shields.io/badge/tools-80-2563eb.svg?style=flat-square)](#tool-reference)
+[![23 APIs](https://img.shields.io/badge/APIs-23-7c3aed.svg?style=flat-square)](#data-sources)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776ab.svg?style=flat-square)](https://python.org)
 [![MCP](https://img.shields.io/badge/protocol-MCP-f97316.svg?style=flat-square)](https://modelcontextprotocol.io)
 
-An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **22 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, disaster management, FDA safety data, national parks, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
+An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **23 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, energy, labor statistics, public health, disaster management, FDA safety data, national parks, open data discovery, cybersecurity, SEC disclosures, and Federal Reserve economic indicators.
 
 Built for practical agent workflows: concise high-level tools, raw query access where it matters, and location-aware inputs that accept city names, ZIP codes, addresses, or raw coordinates.
 
-No API keys required for 14 of 22 sources. Install it, point your MCP client at it, and start querying real civic data.
+No API keys required for 14 of 23 sources. Install it, point your MCP client at it, and start querying real civic data.
 
 [Get Started](#get-started) · [What's New](#whats-new) · [Data Sources](#data-sources) · [Tool Reference](#tool-reference) · [Roadmap](#implementation-roadmap) · [Contributing](CONTRIBUTING.md)
 
@@ -39,7 +39,8 @@ No API keys required for 14 of 22 sources. Install it, point your MCP client at 
         "FRED_API_KEY": "optional",
         "BLS_API_KEY": "optional",
         "NPS_API_KEY": "optional",
-        "EIA_API_KEY": "optional"
+        "EIA_API_KEY": "optional",
+        "USDA_API_KEY": "optional"
       }
     }
   }
@@ -113,6 +114,12 @@ python3 -m mcp_govt_api
 |--------|---------------|-----|
 | [EIA](https://www.eia.gov/opendata/) | Electricity, petroleum, natural gas, coal, and energy market data | Required |
 
+### Food & Agriculture
+
+| Source | What It Covers | Key |
+|--------|---------------|-----|
+| [USDA](https://fdc.nal.usda.gov/) | Food nutrition data (FoodData Central), crop production and acreage (NASS) | Required |
+
 ### Finance & Securities
 
 | Source | What It Covers | Key |
@@ -180,6 +187,9 @@ python3 -m mcp_govt_api
 "Search for national parks in California"
 "Are there any alerts at Yosemite?"
 "Tell me about Grand Canyon National Park"
+"Search for nutritional info on chicken breast"
+"What are the detailed nutrients in FDC ID 171688?"
+"Show me corn production data for Iowa in 2023"
 "What are the current gasoline prices?"
 "Show me electricity data for California"
 "What energy data categories does the EIA provide?"
@@ -362,6 +372,17 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 </details>
 
 <details>
+<summary><strong>Food & Agriculture (USDA)</strong> — 3 tools</summary>
+
+| Tool | Description |
+|------|-------------|
+| `search_usda_foods` | Search FoodData Central for nutritional info on foods |
+| `get_food_details` | Get detailed nutrition data for a specific food by FDC ID |
+| `get_crop_data` | Get NASS crop production, acreage, and yield data by state and year |
+
+</details>
+
+<details>
 <summary><strong>Energy (EIA)</strong> — 3 tools</summary>
 
 | Tool | Description |
@@ -466,6 +487,7 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 | `BLS_API_KEY` | Higher rate limits for BLS (25 to 500 queries/day) | *(works without key)* |
 | `NPS_API_KEY` | Enables National Park Service tools | *(disabled)* |
 | `EIA_API_KEY` | Enables EIA energy market tools | *(disabled)* |
+| `USDA_API_KEY` | Enables USDA food nutrition and crop data tools | *(disabled)* |
 | `API_TIMEOUT` | Request timeout in seconds | `30` |
 
 On startup the server prints which APIs are available:
@@ -480,6 +502,7 @@ API Availability:
   ✓ BLS                   ✓ FEMA
   ✗ OpenWeather (key not set)
   ✗ EIA (key not set)
+  ✗ USDA (key not set)
 ```
 
 ---

--- a/src/mcp_govt_api/server.py
+++ b/src/mcp_govt_api/server.py
@@ -30,6 +30,7 @@ mcp = FastMCP(
 - NOAA CO-OPS (tide predictions, observed water levels, coastal stations)
 - NPS (national parks, park alerts, and park details)
 - EIA (electricity data, petroleum prices, energy market overview; requires API key)
+- USDA (food nutrition via FoodData Central, crop production via NASS; requires API key)
 """,
 )
 
@@ -64,6 +65,7 @@ from mcp_govt_api.tools import (  # noqa: E402
     safecast,  # noqa: F401
     sec,  # noqa: F401
     space_weather,  # noqa: F401
+    usda,  # noqa: F401
     usgs_water,  # noqa: F401
     weather,  # noqa: F401
 )

--- a/src/mcp_govt_api/tools/usda.py
+++ b/src/mcp_govt_api/tools/usda.py
@@ -1,0 +1,234 @@
+from mcp_govt_api.server import mcp
+from mcp_govt_api.utils.http import fetch_json
+from mcp_govt_api.utils.config import config
+
+
+FDC_BASE = "https://api.nal.usda.gov/fdc/v1"
+NASS_BASE = "https://quickstats.nass.usda.gov/api"
+
+
+def _require_key() -> str:
+    """Return the USDA API key or raise an error."""
+    if not config.usda_api_key:
+        raise ValueError(
+            "USDA_API_KEY environment variable is not set. "
+            "Get a free key at https://fdc.nal.usda.gov/api-key-signup.html"
+        )
+    return config.usda_api_key
+
+
+@mcp.tool()
+async def search_usda_foods(
+    query: str,
+    limit: int = 10,
+) -> str:
+    """Search USDA FoodData Central for nutritional information on foods.
+
+    Args:
+        query: Food to search for (e.g., 'apple', 'cheddar cheese', 'chicken breast').
+        limit: Number of results to return (default 10, max 50).
+
+    Returns:
+        Matching foods with basic nutritional data and FDC IDs for detail lookup.
+    """
+    try:
+        api_key = _require_key()
+    except ValueError as exc:
+        return str(exc)
+
+    url = f"{FDC_BASE}/foods/search"
+    params = {
+        "api_key": api_key,
+        "query": query,
+        "pageSize": str(min(limit, 50)),
+    }
+
+    try:
+        data = await fetch_json(url, params=params)
+    except Exception as exc:
+        return f"Error searching FoodData Central: {exc}"
+
+    foods = data.get("foods", [])
+    total = data.get("totalHits", 0)
+
+    if not foods:
+        return f"No foods found matching '{query}'."
+
+    lines = [f"**USDA FoodData Central — '{query}'** ({total} total results)\n"]
+
+    for food in foods:
+        fdc_id = food.get("fdcId", "N/A")
+        description = food.get("description", "Unknown")
+        data_type = food.get("dataType", "")
+        brand = food.get("brandOwner", "")
+
+        parts = [f"  - **{description}**"]
+        if brand:
+            parts[0] += f" ({brand})"
+        parts.append(f"FDC ID: {fdc_id}")
+        if data_type:
+            parts.append(f"Type: {data_type}")
+
+        nutrients = food.get("foodNutrients", [])
+        nutrient_strs = []
+        for n in nutrients:
+            name = n.get("nutrientName", "")
+            value = n.get("value")
+            unit = n.get("unitName", "")
+            if name and value is not None:
+                if name in ("Energy", "Protein", "Total lipid (fat)",
+                            "Carbohydrate, by difference", "Fiber, total dietary"):
+                    nutrient_strs.append(f"{name}: {value} {unit}")
+        if nutrient_strs:
+            parts.append(" | ".join(nutrient_strs))
+
+        lines.append(" | ".join(parts[:3]))
+        if nutrient_strs:
+            lines.append(f"    {' | '.join(nutrient_strs)}")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_food_details(
+    fdc_id: int,
+) -> str:
+    """Get detailed nutrition data for a specific food from USDA FoodData Central.
+
+    Args:
+        fdc_id: FoodData Central ID (get from search_usda_foods results).
+
+    Returns:
+        Comprehensive nutritional information including calories, macros, vitamins, and minerals.
+    """
+    try:
+        api_key = _require_key()
+    except ValueError as exc:
+        return str(exc)
+
+    url = f"{FDC_BASE}/food/{fdc_id}"
+    params = {"api_key": api_key}
+
+    try:
+        data = await fetch_json(url, params=params)
+    except Exception as exc:
+        return f"Error fetching food details: {exc}"
+
+    description = data.get("description", "Unknown Food")
+    data_type = data.get("dataType", "")
+    brand = data.get("brandOwner", "")
+    ingredients = data.get("ingredients", "")
+    serving = data.get("servingSize")
+    serving_unit = data.get("servingSizeUnit", "")
+
+    lines = [f"**{description}**"]
+    if brand:
+        lines.append(f"Brand: {brand}")
+    if data_type:
+        lines.append(f"Data Type: {data_type}")
+    if serving is not None:
+        lines.append(f"Serving Size: {serving} {serving_unit}")
+    if ingredients:
+        lines.append(f"Ingredients: {ingredients}")
+
+    nutrients = data.get("foodNutrients", [])
+    if nutrients:
+        lines.append("\n**Nutrients (per 100g):**")
+        for n in nutrients:
+            nutrient_info = n.get("nutrient", {})
+            name = nutrient_info.get("name", n.get("nutrientName", ""))
+            unit = nutrient_info.get("unitName", n.get("unitName", ""))
+            amount = n.get("amount", n.get("value"))
+            if name and amount is not None:
+                lines.append(f"  - {name}: {amount} {unit}")
+
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_crop_data(
+    commodity: str = "",
+    state: str = "",
+    year: str = "",
+    limit: int = 10,
+) -> str:
+    """Get USDA NASS crop production, acreage, and yield data.
+
+    Args:
+        commodity: Crop name (e.g., 'CORN', 'SOYBEANS', 'WHEAT'). Case-insensitive.
+        state: Two-letter state code (e.g., 'IA', 'IL'). Leave empty for national data.
+        year: Year for data (e.g., '2023'). Leave empty for most recent.
+        limit: Number of records to return (default 10).
+
+    Returns:
+        Crop production statistics including acreage, yield, and production volume.
+    """
+    try:
+        api_key = _require_key()
+    except ValueError as exc:
+        return str(exc)
+
+    url = f"{NASS_BASE}/api_GET/"
+    params: dict = {
+        "key": api_key,
+        "format": "JSON",
+    }
+    if commodity:
+        params["commodity_desc"] = commodity.upper()
+    if state:
+        params["state_alpha"] = state.upper()
+    if year:
+        params["year"] = year
+    # Focus on key statistics
+    params["statisticcat_desc"] = "PRODUCTION"
+
+    try:
+        data = await fetch_json(url, params=params)
+    except Exception as exc:
+        return f"Error fetching NASS crop data: {exc}"
+
+    records = data.get("data", [])
+
+    if not records:
+        parts = []
+        if commodity:
+            parts.append(commodity.upper())
+        if state:
+            parts.append(state.upper())
+        if year:
+            parts.append(year)
+        label = ", ".join(parts) if parts else "the given criteria"
+        return f"No crop data found for {label}."
+
+    # Limit results
+    records = records[:limit]
+
+    title_parts = ["**USDA NASS Crop Data**"]
+    if commodity:
+        title_parts[0] = f"**USDA NASS — {commodity.upper()}**"
+    if state:
+        title_parts.append(f"State: {state.upper()}")
+    if year:
+        title_parts.append(f"Year: {year}")
+
+    lines = [" | ".join(title_parts) + "\n"]
+
+    for rec in records:
+        rec_commodity = rec.get("commodity_desc", "")
+        rec_year = rec.get("year", "")
+        rec_state = rec.get("state_alpha", rec.get("state_name", ""))
+        stat_cat = rec.get("statisticcat_desc", "")
+        short_desc = rec.get("short_desc", "")
+        value = rec.get("Value", "N/A")
+        unit = rec.get("unit_desc", "")
+
+        entry = f"  - **{rec_commodity}** ({rec_year}, {rec_state})"
+        if stat_cat:
+            entry += f" | {stat_cat}"
+        entry += f": {value} {unit}"
+        if short_desc and short_desc != rec_commodity:
+            entry += f"\n    _{short_desc}_"
+
+        lines.append(entry)
+
+    return "\n".join(lines)

--- a/src/mcp_govt_api/utils/config.py
+++ b/src/mcp_govt_api/utils/config.py
@@ -12,6 +12,7 @@ class Config:
     bls_api_key: str | None = None
     nps_api_key: str | None = None
     eia_api_key: str | None = None
+    usda_api_key: str | None = None
     timeout: int = 30
 
     def __post_init__(self):
@@ -21,6 +22,7 @@ class Config:
         self.bls_api_key = os.environ.get("BLS_API_KEY")
         self.nps_api_key = os.environ.get("NPS_API_KEY")
         self.eia_api_key = os.environ.get("EIA_API_KEY")
+        self.usda_api_key = os.environ.get("USDA_API_KEY")
         self.timeout = int(os.environ.get("API_TIMEOUT", "30"))
 
     @property
@@ -46,6 +48,10 @@ class Config:
     @property
     def has_eia(self) -> bool:
         return bool(self.eia_api_key)
+
+    @property
+    def has_usda(self) -> bool:
+        return bool(self.usda_api_key)
 
     def get_availability_summary(self) -> str:
         """Return a summary of API availability."""
@@ -92,6 +98,10 @@ class Config:
             lines.append("  ✓ EIA (API key configured)")
         else:
             lines.append("  ✗ EIA (EIA_API_KEY not set)")
+        if self.has_usda:
+            lines.append("  ✓ USDA (API key configured)")
+        else:
+            lines.append("  ✗ USDA (USDA_API_KEY not set)")
         if self.has_nasa_key:
             lines.append("  ✓ NASA FIRMS (using NASA API key)")
         else:

--- a/tests/test_usda.py
+++ b/tests/test_usda.py
@@ -1,0 +1,211 @@
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from mcp_govt_api.tools.usda import (
+    get_crop_data,
+    get_food_details,
+    search_usda_foods,
+)
+
+
+class SearchUsdaFoodsTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_error_when_key_missing(self):
+        with patch("mcp_govt_api.tools.usda.config") as mock_config:
+            mock_config.usda_api_key = None
+            result = await search_usda_foods(query="apple")
+
+        self.assertIn("USDA_API_KEY", result)
+
+    async def test_returns_formatted_search_results(self):
+        api_response = {
+            "totalHits": 25,
+            "foods": [
+                {
+                    "fdcId": 171688,
+                    "description": "Apples, raw, with skin",
+                    "dataType": "SR Legacy",
+                    "brandOwner": "",
+                    "foodNutrients": [
+                        {"nutrientName": "Energy", "value": 52, "unitName": "KCAL"},
+                        {"nutrientName": "Protein", "value": 0.26, "unitName": "G"},
+                        {
+                            "nutrientName": "Carbohydrate, by difference",
+                            "value": 13.81,
+                            "unitName": "G",
+                        },
+                    ],
+                }
+            ],
+        }
+        with patch("mcp_govt_api.tools.usda.config") as mock_config, patch(
+            "mcp_govt_api.tools.usda.fetch_json",
+            new=AsyncMock(return_value=api_response),
+        ):
+            mock_config.usda_api_key = "test-key"
+            result = await search_usda_foods(query="apple", limit=10)
+
+        self.assertIn("FoodData Central", result)
+        self.assertIn("apple", result)
+        self.assertIn("Apples, raw, with skin", result)
+        self.assertIn("171688", result)
+        self.assertIn("Energy", result)
+
+    async def test_empty_results(self):
+        api_response = {"totalHits": 0, "foods": []}
+        with patch("mcp_govt_api.tools.usda.config") as mock_config, patch(
+            "mcp_govt_api.tools.usda.fetch_json",
+            new=AsyncMock(return_value=api_response),
+        ):
+            mock_config.usda_api_key = "test-key"
+            result = await search_usda_foods(query="xyzzyx")
+
+        self.assertIn("No foods found", result)
+
+    async def test_api_error_handled(self):
+        with patch("mcp_govt_api.tools.usda.config") as mock_config, patch(
+            "mcp_govt_api.tools.usda.fetch_json",
+            new=AsyncMock(side_effect=Exception("timeout")),
+        ):
+            mock_config.usda_api_key = "test-key"
+            result = await search_usda_foods(query="apple")
+
+        self.assertIn("Error", result)
+
+
+class GetFoodDetailsTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_error_when_key_missing(self):
+        with patch("mcp_govt_api.tools.usda.config") as mock_config:
+            mock_config.usda_api_key = None
+            result = await get_food_details(fdc_id=171688)
+
+        self.assertIn("USDA_API_KEY", result)
+
+    async def test_returns_formatted_food_details(self):
+        api_response = {
+            "fdcId": 171688,
+            "description": "Apples, raw, with skin",
+            "dataType": "SR Legacy",
+            "brandOwner": "",
+            "servingSize": 182,
+            "servingSizeUnit": "g",
+            "ingredients": "",
+            "foodNutrients": [
+                {
+                    "nutrient": {"name": "Energy", "unitName": "KCAL"},
+                    "amount": 52,
+                },
+                {
+                    "nutrient": {"name": "Protein", "unitName": "G"},
+                    "amount": 0.26,
+                },
+            ],
+        }
+        with patch("mcp_govt_api.tools.usda.config") as mock_config, patch(
+            "mcp_govt_api.tools.usda.fetch_json",
+            new=AsyncMock(return_value=api_response),
+        ):
+            mock_config.usda_api_key = "test-key"
+            result = await get_food_details(fdc_id=171688)
+
+        self.assertIn("Apples, raw, with skin", result)
+        self.assertIn("Energy", result)
+        self.assertIn("52", result)
+        self.assertIn("Protein", result)
+        self.assertIn("Serving Size", result)
+
+    async def test_api_error_handled(self):
+        with patch("mcp_govt_api.tools.usda.config") as mock_config, patch(
+            "mcp_govt_api.tools.usda.fetch_json",
+            new=AsyncMock(side_effect=Exception("not found")),
+        ):
+            mock_config.usda_api_key = "test-key"
+            result = await get_food_details(fdc_id=999999)
+
+        self.assertIn("Error", result)
+
+
+class GetCropDataTests(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_error_when_key_missing(self):
+        with patch("mcp_govt_api.tools.usda.config") as mock_config:
+            mock_config.usda_api_key = None
+            result = await get_crop_data(commodity="CORN")
+
+        self.assertIn("USDA_API_KEY", result)
+
+    async def test_returns_formatted_crop_data(self):
+        api_response = {
+            "data": [
+                {
+                    "commodity_desc": "CORN",
+                    "year": "2023",
+                    "state_alpha": "IA",
+                    "state_name": "IOWA",
+                    "statisticcat_desc": "PRODUCTION",
+                    "short_desc": "CORN, GRAIN - PRODUCTION, MEASURED IN BU",
+                    "Value": "2,382,400,000",
+                    "unit_desc": "BU",
+                }
+            ]
+        }
+        with patch("mcp_govt_api.tools.usda.config") as mock_config, patch(
+            "mcp_govt_api.tools.usda.fetch_json",
+            new=AsyncMock(return_value=api_response),
+        ):
+            mock_config.usda_api_key = "test-key"
+            result = await get_crop_data(commodity="CORN", state="IA", year="2023")
+
+        self.assertIn("CORN", result)
+        self.assertIn("2023", result)
+        self.assertIn("IA", result)
+        self.assertIn("PRODUCTION", result)
+        self.assertIn("BU", result)
+
+    async def test_empty_results(self):
+        api_response = {"data": []}
+        with patch("mcp_govt_api.tools.usda.config") as mock_config, patch(
+            "mcp_govt_api.tools.usda.fetch_json",
+            new=AsyncMock(return_value=api_response),
+        ):
+            mock_config.usda_api_key = "test-key"
+            result = await get_crop_data(commodity="XYZZYX")
+
+        self.assertIn("No crop data found", result)
+
+    async def test_national_data_no_state(self):
+        api_response = {
+            "data": [
+                {
+                    "commodity_desc": "SOYBEANS",
+                    "year": "2023",
+                    "state_alpha": "US",
+                    "state_name": "US TOTAL",
+                    "statisticcat_desc": "PRODUCTION",
+                    "short_desc": "SOYBEANS - PRODUCTION, MEASURED IN BU",
+                    "Value": "4,165,000,000",
+                    "unit_desc": "BU",
+                }
+            ]
+        }
+        with patch("mcp_govt_api.tools.usda.config") as mock_config, patch(
+            "mcp_govt_api.tools.usda.fetch_json",
+            new=AsyncMock(return_value=api_response),
+        ):
+            mock_config.usda_api_key = "test-key"
+            result = await get_crop_data(commodity="SOYBEANS", year="2023")
+
+        self.assertIn("SOYBEANS", result)
+        self.assertIn("US", result)
+
+    async def test_api_error_handled(self):
+        with patch("mcp_govt_api.tools.usda.config") as mock_config, patch(
+            "mcp_govt_api.tools.usda.fetch_json",
+            new=AsyncMock(side_effect=Exception("timeout")),
+        ):
+            mock_config.usda_api_key = "test-key"
+            result = await get_crop_data(commodity="CORN")
+
+        self.assertIn("Error", result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- 3 new tools: `search_usda_foods`, `get_food_details`, `get_crop_data`
- Uses FoodData Central + NASS QuickStats APIs with optional API key; 12 tests
Closes #65
🤖 Generated with [Claude Code](https://claude.com/claude-code)