### PR TITLE
Add public FAA aviation data wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@
 
 [![MIT License](https://img.shields.io/badge/License-MIT-green.svg?style=flat-square)](LICENSE)
 [![CI](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml/badge.svg)](https://github.com/EricGrill/mcp-civic-data/actions/workflows/ci.yml)
-[![110 Tools](https://img.shields.io/badge/tools-110-2563eb.svg?style=flat-square)](#tool-reference)
-[![33 APIs](https://img.shields.io/badge/APIs-33-7c3aed.svg?style=flat-square)](#data-sources)
+[![172 Tools](https://img.shields.io/badge/tools-172-2563eb.svg?style=flat-square)](#tool-reference)
+[![34 APIs](https://img.shields.io/badge/APIs-34-7c3aed.svg?style=flat-square)](#data-sources)
 [![Python 3.11+](https://img.shields.io/badge/python-3.11+-3776ab.svg?style=flat-square)](https://python.org)
 [![MCP](https://img.shields.io/badge/protocol-MCP-f97316.svg?style=flat-square)](https://modelcontextprotocol.io)
 
-An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **33 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, education, energy, labor statistics, public health, clinical trials, behavioral health, healthcare quality, disaster management, EPA environmental compliance, FDA safety data, vehicle safety, workplace safety, national parks, national forests, consumer financial protection, open data discovery, cybersecurity, SEC disclosures, Federal Reserve economic indicators, BEA economic accounts, BTS transportation data, SBA small business data, USDA food and agriculture data, USFS wildfire and forest data, and FBI crime/justice statistics.
+An [MCP](https://modelcontextprotocol.io) server that connects AI agents to **34 free, authoritative public data APIs** across weather, hazards, air quality, water, tides, radiation, demographics, economics, education, energy, labor statistics, public health, clinical trials, behavioral health, healthcare quality, disaster management, EPA environmental compliance, FDA safety data, vehicle safety, workplace safety, national parks, national forests, consumer financial protection, open data discovery, cybersecurity, SEC disclosures, Federal Reserve economic indicators, BEA economic accounts, BTS transportation data, FAA aviation data, SBA small business data, USDA food and agriculture data, USFS wildfire and forest data, and FBI crime/justice statistics.
 
 Built for practical agent workflows: concise high-level tools, raw query access where it matters, and location-aware inputs that accept city names, ZIP codes, addresses, or raw coordinates.
 
-No API keys required for 22 of 33 sources. Install it, point your MCP client at it, and start querying real civic data.
+No API keys required for 23 of 34 sources. Install it, point your MCP client at it, and start querying real civic data.
 
 [Get Started](#get-started) · [What's New](#whats-new) · [Data Sources](#data-sources) · [Tool Reference](#tool-reference) · [Roadmap](#implementation-roadmap) · [Contributing](CONTRIBUTING.md)
 
@@ -74,6 +74,7 @@ python3 -m mcp_govt_api
 - Added GitHub Actions CI for install, compile, unit test, import, and build validation
 - Added `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, and `SECURITY.md`
 - Added BEA regional and national economic accounts tools (GDP, income, industry)
+- Added FAA public aviation tools for AIS geodata, TFRs, NAS Status, aircraft registry, and aircraft type characteristics
 - Added branch protection and required automated checks on `main`
 
 ---
@@ -141,6 +142,7 @@ python3 -m mcp_govt_api
 | Source | What It Covers | Key |
 |--------|---------------|-----|
 | [BTS](https://data.bts.gov) | Airline on-time performance, border crossing data, transportation datasets | -- |
+| [FAA Public Aviation Data](https://www.faa.gov/data) | AIS airport/geodata, TFRs, NAS status, aircraft registry, aircraft characteristics, FAA catalog | -- |
 
 ### Small Business
 
@@ -254,6 +256,10 @@ python3 -m mcp_govt_api
 "Show me airline on-time stats for American Airlines"
 "What's the border crossing data for El Paso?"
 "Search BTS datasets about freight"
+"Are there active TFRs in Virginia?"
+"Look up FAA airport and runway data for LAX"
+"Is DCA currently affected by FAA NAS delays or closures?"
+"Look up FAA aircraft registration N23FX"
 "Search SBA datasets for PPP loans"
 "What is the SBA size standard for restaurants?"
 "Show me SBA disaster loans in Florida"
@@ -683,6 +689,36 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 </details>
 
 <details>
+<summary><strong>FAA Aviation</strong> — 22 tools</summary>
+
+| Tool | Description |
+|------|-------------|
+| `search_faa_airports` | Search FAA AIS airport geodata by identifier, name, city, or state |
+| `get_faa_airport` | FAA AIS airport details by FAA identifier or ICAO ID |
+| `get_faa_runways` | FAA AIS runway records for an airport |
+| `get_faa_airspace_near` | FAA class and special-use airspace near a coordinate |
+| `get_faa_uas_facility_map` | FAA UAS Facility Map records near a coordinate |
+| `query_faa_ais` | Raw bounded FAA AIS ArcGIS FeatureServer query |
+| `get_faa_tfrs` | Active FAA Temporary Flight Restrictions with optional filters |
+| `get_faa_tfr_summary` | FAA TFR counts by center/facility |
+| `get_faa_tfr_shapes` | Active FAA TFR GeoJSON-style shapes |
+| `get_faa_tfr_detail` | Parsed FAA TFR detail XML for a NOTAM ID |
+| `get_faa_nas_airport_events` | Current FAA NAS airport events |
+| `get_faa_ground_stops` | Current FAA NAS ground stop events |
+| `get_faa_ground_delays` | Current FAA NAS ground delay events |
+| `get_faa_airport_closures` | Current FAA NAS airport closure events |
+| `get_faa_operations_plan` | Current FAA NAS operations plan JSON |
+| `get_faa_artcc_boundaries` | FAA NAS ARTCC boundary data |
+| `lookup_faa_aircraft_registration` | Bounded FAA aircraft registry lookup by N-number |
+| `search_faa_aircraft_registry` | Bounded FAA aircraft registry search by make/model/state/status |
+| `get_faa_aircraft_type_characteristics` | FAA aircraft type characteristics lookup |
+| `search_faa_aircraft_type_characteristics` | FAA aircraft type characteristics search |
+| `search_faa_catalog` | FAA Data Catalog CKAN search |
+| `query_faa_catalog` | Raw FAA Data Catalog CKAN query |
+
+</details>
+
+<details>
 <summary><strong>Open Data</strong> — 6 tools</summary>
 
 | Tool | Description |
@@ -698,6 +734,29 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 
 ---
 
+## FAA Source Notes
+
+First-wave FAA tools use public no-key sources:
+
+| Source | Endpoint family | Freshness | Caveat |
+|--------|-----------------|-----------|--------|
+| FAA AIS ArcGIS FeatureServers | `services6.arcgis.com/.../FeatureServer` | FAA AIS publication cycle; service metadata exposes edit dates | Informational geodata only |
+| FAA TFR | `tfr.faa.gov/tfrapi` and GeoServer WFS | Active FAA TFR site data | Verify official FAA/briefing sources before operational use |
+| FAA NAS Status | `nasstatus.faa.gov/api` | Current NAS Status API data | Status data can change quickly |
+| FAA Aircraft Registry | `registry.faa.gov/database/ReleasableAircraft.zip` | Daily public ZIP download | Public records may include owner information; searches are bounded |
+| FAA Aircraft Characteristics | FAA downloadable workbook | FAA published workbook update cadence | Type characteristics, not individual aircraft or live operations |
+| FAA Data Catalog | `catalog.data.faa.gov/api/3` | Catalog metadata update cadence | Discovery only; resources vary |
+
+FAA aviation tools are informational only. Verify official FAA, NOTAM, chart, and flight briefing sources before making operational decisions. Aircraft registry tools use public FAA records and keep searches bounded because registry data can include owner information.
+
+Deferred FAA-adjacent integrations:
+
+- FAA Developer Portal products: require FAA account/API key.
+- FAA SWIM: requires access agreement.
+- Full NOTAM Search/NMS scraping: deferred; TFR data is the first-wave NOTAM subset.
+- NOAA Aviation Weather Center: useful aviation weather data, but not FAA-owned.
+- FAA Wildlife Strike API: deferred until a production hostname and public-use terms are confirmed; no POST/add/update/upload endpoints are included.
+
 ## Configuration
 
 | Variable | Purpose | Default |
@@ -712,6 +771,7 @@ Every data source exposes **high-level tools** for common queries and a **raw qu
 | `USDA_API_KEY` | Enables USDA food nutrition and crop data tools | *(disabled)* |
 | `FBI_CDE_API_KEY` | Enables FBI Crime Data Explorer / BJS crime tools | *(disabled)* |
 | `API_TIMEOUT` | Request timeout in seconds | `30` |
+| `MCP_CIVIC_DATA_CACHE_DIR` | Optional cache root for FAA registry/workbook downloads | `~/.cache/mcp-civic-data` |
 
 On startup the server prints which APIs are available:
 
@@ -725,6 +785,7 @@ API Availability:
   ✓ BLS                   ✓ FEMA
   ✓ SBA                   ✓ CFPB
   ✓ CMS Healthcare        ✓ SAMHSA
+  ✓ FAA Public Aviation Data
   ✗ OpenWeather (key not set)
   ✗ EIA (key not set)
   ✗ BEA (key not set)

--- a/src/mcp_govt_api/server.py
+++ b/src/mcp_govt_api/server.py
@@ -57,6 +57,7 @@ mcp = FastMCP(
 - Cloudflare Radar (internet traffic, top domains, DDoS attacks)
 - IHR Internet Health (network disconnections, delays, AS hegemony)
 - Service Outages (status page monitoring for GitHub, Slack, etc.)
+- FAA public aviation data (AIS geodata, TFRs, NAS status, registry)
 """,
 )
 
@@ -73,6 +74,7 @@ def main():
 from mcp_govt_api.tools import (  # noqa: E402
     bea,  # noqa: F401
     bjs,  # noqa: F401
+    blitzortung,  # noqa: F401
     bls,  # noqa: F401
     bts,  # noqa: F401
     cdc,  # noqa: F401
@@ -80,46 +82,43 @@ from mcp_govt_api.tools import (  # noqa: E402
     cfpb,  # noqa: F401
     cisa,  # noqa: F401
     clinical_trials,  # noqa: F401
+    cloudflare_radar,  # noqa: F401
     cms,  # noqa: F401
     datagov,  # noqa: F401
+    disaster_events,  # noqa: F401
     earthquakes,  # noqa: F401
     economics,  # noqa: F401
     eia,  # noqa: F401
     epa,  # noqa: F401
     eu_data,  # noqa: F401
+    faa,  # noqa: F401
     fda,  # noqa: F401
     fema,  # noqa: F401
     firms,  # noqa: F401
     fred,  # noqa: F401
+    internet_health,  # noqa: F401
     location,  # noqa: F401
+    n2yo,  # noqa: F401
     nasa,  # noqa: F401
     nces,  # noqa: F401
     nhtsa,  # noqa: F401
     noaa_coops,  # noqa: F401
+    noaa_imagery,  # noqa: F401
     noaa_weather,  # noqa: F401
     nps,  # noqa: F401
     openaq,  # noqa: F401
     osha,  # noqa: F401
+    outages,  # noqa: F401
+    railway,  # noqa: F401
     safecast,  # noqa: F401
     samhsa,  # noqa: F401
     sba,  # noqa: F401
     sec,  # noqa: F401
     space_weather,  # noqa: F401
+    submarine_cables,  # noqa: F401
     usda,  # noqa: F401
     usfs,  # noqa: F401
     usgs_water,  # noqa: F401
-    weather,  # noqa: F401
-)
-
-from mcp_govt_api.tools import (  # noqa: E402
-    blitzortung,  # noqa: F401
-    cloudflare_radar,  # noqa: F401
-    disaster_events,  # noqa: F401
-    internet_health,  # noqa: F401
-    n2yo,  # noqa: F401
-    noaa_imagery,  # noqa: F401
-    outages,  # noqa: F401
-    railway,  # noqa: F401
-    submarine_cables,  # noqa: F401
     volcanoes,  # noqa: F401
+    weather,  # noqa: F401
 )

--- a/src/mcp_govt_api/tools/bea.py
+++ b/src/mcp_govt_api/tools/bea.py
@@ -2,7 +2,6 @@ from mcp_govt_api.server import mcp
 from mcp_govt_api.utils.config import config
 from mcp_govt_api.utils.http import fetch_json
 
-
 BEA_BASE = "https://apps.bea.gov/api/data/"
 
 
@@ -63,10 +62,7 @@ async def get_bea_regional_data(
     geo_fips = "STATE"
     if state:
         upper = state.upper()
-        if upper in state_fips:
-            geo_fips = state_fips[upper]
-        else:
-            geo_fips = upper
+        geo_fips = state_fips.get(upper, upper)
 
     params: dict = {
         "UserID": api_key,

--- a/src/mcp_govt_api/tools/bjs.py
+++ b/src/mcp_govt_api/tools/bjs.py
@@ -2,7 +2,6 @@ from mcp_govt_api.server import mcp
 from mcp_govt_api.utils.config import config
 from mcp_govt_api.utils.http import fetch_json
 
-
 FBI_CDE_BASE = "https://api.usa.gov/crime/fbi/cde"
 
 
@@ -48,10 +47,11 @@ async def get_crime_estimates(
         "API_KEY": api_key,
     }
 
-    if state:
-        url = f"{FBI_CDE_BASE}/estimate/state/{state.upper()}"
-    else:
-        url = f"{FBI_CDE_BASE}/estimate/national"
+    url = (
+        f"{FBI_CDE_BASE}/estimate/state/{state.upper()}"
+        if state
+        else f"{FBI_CDE_BASE}/estimate/national"
+    )
 
     try:
         data = await fetch_json(url, params=params)
@@ -139,10 +139,11 @@ async def get_arrest_data(
         "API_KEY": api_key,
     }
 
-    if offense:
-        url = f"{FBI_CDE_BASE}/arrest/national/{offense}"
-    else:
-        url = f"{FBI_CDE_BASE}/arrest/national"
+    url = (
+        f"{FBI_CDE_BASE}/arrest/national/{offense}"
+        if offense
+        else f"{FBI_CDE_BASE}/arrest/national"
+    )
 
     try:
         data = await fetch_json(url, params=params)
@@ -193,13 +194,22 @@ async def get_arrest_data(
             if isinstance(juvenile, (int, float)):
                 lines.append(f"  Juvenile: {juvenile:,}")
 
+        ignored_keys = {
+            "year",
+            "data_year",
+            "total_arrests",
+            "value",
+            "male",
+            "female",
+            "juvenile",
+            "adult",
+            "month",
+            "month_num",
+        }
         for key, val in entry.items():
-            if key not in ("year", "data_year", "total_arrests", "value",
-                           "male", "female", "juvenile", "adult",
-                           "month", "month_num"):
-                if isinstance(val, (int, float)) and val > 0:
-                    label = key.replace("_", " ").title()
-                    lines.append(f"  {label}: {val:,}")
+            if key not in ignored_keys and isinstance(val, (int, float)) and val > 0:
+                label = key.replace("_", " ").title()
+                lines.append(f"  {label}: {val:,}")
         lines.append("")
 
     lines.append("_Source: FBI Crime Data Explorer (UCR)_")

--- a/src/mcp_govt_api/tools/blitzortung.py
+++ b/src/mcp_govt_api/tools/blitzortung.py
@@ -1,3 +1,5 @@
+from contextlib import suppress
+
 from mcp_govt_api.server import mcp
 from mcp_govt_api.utils.http import fetch_json
 
@@ -150,10 +152,8 @@ async def get_lightning_summary(region: int = 1, minutes: int = 60) -> str:
 
             sig = props.get("sig")
             if sig is not None:
-                try:
+                with suppress(TypeError, ValueError):
                     station_counts.append(int(sig))
-                except (TypeError, ValueError):
-                    pass
 
         rate = total / max(minutes, 1)
 

--- a/src/mcp_govt_api/tools/bls.py
+++ b/src/mcp_govt_api/tools/bls.py
@@ -1,7 +1,6 @@
 from mcp_govt_api.server import mcp
-from mcp_govt_api.utils.http import http_client
 from mcp_govt_api.utils.config import config
-
+from mcp_govt_api.utils.http import http_client
 
 BLS_BASE = "https://api.bls.gov/publicAPI/v2/timeseries/data/"
 
@@ -134,7 +133,7 @@ async def _fetch_bls_series(
         response.raise_for_status()
         return response.json()
     except Exception as e:
-        raise Exception(f"BLS API request failed: {e}")
+        raise Exception(f"BLS API request failed: {e}") from e
 
 
 @mcp.tool()

--- a/src/mcp_govt_api/tools/cdc.py
+++ b/src/mcp_govt_api/tools/cdc.py
@@ -1,7 +1,8 @@
+from datetime import UTC
+
 from mcp_govt_api.server import mcp
 from mcp_govt_api.utils.config import config
 from mcp_govt_api.utils.http import fetch_json
-
 
 CDC_OPEN_DATA_BASE = "https://data.cdc.gov"
 CDC_NNDSS_DATASET = "x9gk-5huc"
@@ -49,11 +50,11 @@ async def search_cdc_datasets(
         updated = ds.get("rowsUpdatedAt")
         updated_str = ""
         if updated:
-            from datetime import datetime, timezone
+            from datetime import datetime
 
             try:
                 updated_str = datetime.fromtimestamp(
-                    updated, tz=timezone.utc
+                    updated, tz=UTC
                 ).strftime("%Y-%m-%d")
             except (ValueError, OSError):
                 updated_str = "Unknown"

--- a/src/mcp_govt_api/tools/cfpb.py
+++ b/src/mcp_govt_api/tools/cfpb.py
@@ -183,13 +183,13 @@ async def get_cfpb_complaint(complaint_id: str) -> str:
         lines.append(f"Consumer Consent Provided: {consumer_consent}")
 
     if narrative:
-        lines.append(f"\n**Consumer Narrative:**")
+        lines.append("\n**Consumer Narrative:**")
         if len(narrative) > 1000:
             lines.append(narrative[:1000] + "...")
         else:
             lines.append(narrative)
 
-    lines.append(f"\n_Source: CFPB Consumer Complaint Database_")
+    lines.append("\n_Source: CFPB Consumer Complaint Database_")
 
     return "\n".join(lines)
 

--- a/src/mcp_govt_api/tools/disaster_events.py
+++ b/src/mcp_govt_api/tools/disaster_events.py
@@ -26,7 +26,7 @@ def _build_fields_params(fields: list[str]) -> dict[str, str]:
     """Build query parameters for ReliefWeb field selection."""
     params: dict[str, str] = {}
     for field in fields:
-        params[f"fields[include][]"] = field  # httpx handles list params
+        params["fields[include][]"] = field  # httpx handles list params
     return params
 
 
@@ -82,13 +82,6 @@ async def get_recent_disasters(
 
     # Build URL with filters
     url = f"{BASE_URL}/disasters"
-
-    # For filters, we need to use the query parameter approach
-    query_params: dict = {
-        "appname": APP_NAME,
-        "limit": limit,
-        "sort[]": "date:desc",
-    }
 
     try:
         # Build the full URL with field parameters

--- a/src/mcp_govt_api/tools/eia.py
+++ b/src/mcp_govt_api/tools/eia.py
@@ -1,7 +1,6 @@
 from mcp_govt_api.server import mcp
-from mcp_govt_api.utils.http import fetch_json
 from mcp_govt_api.utils.config import config
-
+from mcp_govt_api.utils.http import fetch_json
 
 EIA_BASE = "https://api.eia.gov/v2"
 
@@ -185,10 +184,7 @@ async def get_energy_overview(
     except ValueError as exc:
         return str(exc)
 
-    if category:
-        url = f"{EIA_BASE}/{category}"
-    else:
-        url = EIA_BASE
+    url = f"{EIA_BASE}/{category}" if category else EIA_BASE
 
     params = {"api_key": api_key}
 

--- a/src/mcp_govt_api/tools/epa.py
+++ b/src/mcp_govt_api/tools/epa.py
@@ -54,7 +54,6 @@ async def search_epa_facilities(
         return "No EPA-regulated facilities found matching the given criteria."
 
     facilities = facilities[:limit]
-    total = results.get("Message", "")
 
     lines = [f"EPA-Regulated Facilities ({len(facilities)} results):\n"]
 

--- a/src/mcp_govt_api/tools/faa.py
+++ b/src/mcp_govt_api/tools/faa.py
@@ -1,0 +1,1214 @@
+import csv
+import io
+import json
+import math
+import os
+import re
+import time
+import zipfile
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree
+
+from mcp_govt_api.server import mcp
+from mcp_govt_api.utils.http import fetch_bytes, fetch_json, fetch_text
+
+PUBLIC_AVIATION_DISCLAIMER = (
+    "FAA aviation data is provided for informational use only; verify official FAA, "
+    "NOTAM, chart, and flight briefing sources before making operational decisions."
+)
+
+REGISTRY_PRIVACY_CAVEAT = (
+    "FAA aircraft registry records are public records and may include owner "
+    "information; searches are intentionally bounded."
+)
+
+FAA_SOURCES: dict[str, dict[str, str]] = {
+    "FAA AIS": {
+        "auth": "none",
+        "freshness": "FAA AIS publication cycle; service metadata reports edit dates",
+        "url": "https://adds-faa.opendata.arcgis.com/",
+        "caveat": PUBLIC_AVIATION_DISCLAIMER,
+    },
+    "FAA TFR": {
+        "auth": "none",
+        "freshness": "active FAA TFR site data",
+        "url": "https://tfr.faa.gov/",
+        "caveat": PUBLIC_AVIATION_DISCLAIMER,
+    },
+    "FAA NAS Status": {
+        "auth": "none",
+        "freshness": "current NAS Status API data",
+        "url": "https://nasstatus.faa.gov/",
+        "caveat": PUBLIC_AVIATION_DISCLAIMER,
+    },
+    "FAA Aircraft Registry": {
+        "auth": "none",
+        "freshness": "daily FAA registry ZIP download",
+        "url": "https://registry.faa.gov/database/ReleasableAircraft.zip",
+        "caveat": REGISTRY_PRIVACY_CAVEAT,
+    },
+    "FAA Aircraft Characteristics": {
+        "auth": "none",
+        "freshness": "FAA published aircraft characteristics workbook",
+        "url": "https://www.faa.gov/airports/engineering/aircraft_char_database/aircraft_data",
+        "caveat": "Aircraft type characteristics, not live operational data.",
+    },
+    "FAA Data Catalog": {
+        "auth": "none",
+        "freshness": "FAA CKAN catalog metadata",
+        "url": "https://catalog.data.faa.gov/api/3/action/package_search",
+        "caveat": "Catalog discovery only; dataset resources vary.",
+    },
+    "FAA Wildlife Strike": {
+        "auth": "unverified",
+        "freshness": "deferred pending production-host validation",
+        "url": "https://qa-wildlife.faa.gov/api/swagger/v1/swagger.json",
+        "caveat": "Candidate API only; QA-looking hostname is not wrapped in first wave.",
+    },
+}
+
+FAA_ARCGIS_BASE = "https://services6.arcgis.com/ssFJjBXIUyZDrSYZ/arcgis/rest/services"
+FAA_AIS_SERVICES = {
+    "airports": f"{FAA_ARCGIS_BASE}/US_Airport/FeatureServer/0/query",
+    "runways": f"{FAA_ARCGIS_BASE}/Runways/FeatureServer/0/query",
+    "class_airspace": f"{FAA_ARCGIS_BASE}/Class_Airspace/FeatureServer/0/query",
+    "special_use_airspace": f"{FAA_ARCGIS_BASE}/Special_Use_Airspace/FeatureServer/0/query",
+    "navaids": f"{FAA_ARCGIS_BASE}/NAVAIDSystem/FeatureServer/0/query",
+    "designated_points": f"{FAA_ARCGIS_BASE}/DesignatedPoints/FeatureServer/0/query",
+    "obstacles": f"{FAA_ARCGIS_BASE}/Digital_Obstacle_File/FeatureServer/0/query",
+    "uas_facility_map": f"{FAA_ARCGIS_BASE}/FAA_UAS_FacilityMap_Data_V5/FeatureServer/0/query",
+}
+
+FAA_TFR_BASE = "https://tfr.faa.gov"
+FAA_TFR_API_BASE = f"{FAA_TFR_BASE}/tfrapi"
+FAA_TFR_WFS_URL = f"{FAA_TFR_BASE}/geoserver/TFR/ows"
+FAA_NAS_API_BASE = "https://nasstatus.faa.gov/api"
+FAA_CATALOG_BASE = "https://catalog.data.faa.gov/api/3"
+FAA_REGISTRY_ZIP_URL = "https://registry.faa.gov/database/ReleasableAircraft.zip"
+FAA_AIRCRAFT_CHARACTERISTICS_URL = (
+    "https://www.faa.gov/airports/engineering/aircraft_char_database/aircraft_data"
+)
+
+
+def _cache_dir() -> Path:
+    root = os.environ.get("MCP_CIVIC_DATA_CACHE_DIR")
+    if root:
+        return Path(root) / "faa"
+    return Path.home() / ".cache" / "mcp-civic-data" / "faa"
+
+
+async def _cached_bytes(url: str, cache_name: str, max_age_seconds: int) -> bytes:
+    cache_path = _cache_dir() / cache_name
+    if cache_path.exists():
+        age = time.time() - cache_path.stat().st_mtime
+        if age <= max_age_seconds:
+            return cache_path.read_bytes()
+
+    data = await fetch_bytes(url)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    cache_path.write_bytes(data)
+    return data
+
+
+def _limit(value: int, *, default: int = 10, maximum: int = 50) -> int:
+    if value <= 0:
+        return default
+    return min(value, maximum)
+
+
+def _sql_quote(value: str) -> str:
+    return value.replace("'", "''")
+
+
+def _contains(field: str, value: str) -> str:
+    return f"UPPER({field}) LIKE '%{_sql_quote(value.upper())}%'"
+
+
+def _equals(field: str, value: str) -> str:
+    return f"{field} = '{_sql_quote(value.upper())}'"
+
+
+def _equals_raw(field: str, value: str) -> str:
+    return f"{field} = '{_sql_quote(value)}'"
+
+
+def _airport_identifier_where(identifier: str) -> str:
+    ident = identifier.strip().upper()
+    clauses = {_equals("IDENT", ident), _equals("ICAO_ID", ident)}
+    if ident.startswith("K") and len(ident) == 4:
+        clauses.add(_equals("IDENT", ident[1:]))
+    elif len(ident) == 3:
+        clauses.add(_equals("ICAO_ID", f"K{ident}"))
+    return " OR ".join(sorted(clauses))
+
+
+def build_arcgis_query_params(
+    *,
+    where: str = "1=1",
+    out_fields: list[str] | None = None,
+    limit: int = 10,
+    bbox: tuple[float, float, float, float] | None = None,
+    return_geometry: bool = True,
+) -> dict[str, Any]:
+    """Build bounded ArcGIS FeatureServer query parameters."""
+    params: dict[str, Any] = {
+        "f": "json",
+        "where": where or "1=1",
+        "outFields": ",".join(out_fields or ["*"]),
+        "returnGeometry": "true" if return_geometry else "false",
+        "outSR": 4326,
+        "resultRecordCount": _limit(limit, maximum=100),
+    }
+    if bbox:
+        xmin, ymin, xmax, ymax = bbox
+        params.update(
+            {
+                "geometryType": "esriGeometryEnvelope",
+                "spatialRel": "esriSpatialRelIntersects",
+                "inSR": 4326,
+                "geometry": json.dumps(
+                    {
+                        "xmin": xmin,
+                        "ymin": ymin,
+                        "xmax": xmax,
+                        "ymax": ymax,
+                        "spatialReference": {"wkid": 4326},
+                    }
+                ),
+            }
+        )
+    return params
+
+
+async def _query_arcgis(
+    service: str,
+    *,
+    where: str = "1=1",
+    out_fields: list[str] | None = None,
+    limit: int = 10,
+    bbox: tuple[float, float, float, float] | None = None,
+    return_geometry: bool = True,
+) -> dict[str, Any]:
+    if service not in FAA_AIS_SERVICES:
+        valid = ", ".join(sorted(FAA_AIS_SERVICES))
+        return {"error": f"Unknown FAA AIS service '{service}'. Valid services: {valid}"}
+    params = build_arcgis_query_params(
+        where=where,
+        out_fields=out_fields,
+        limit=limit,
+        bbox=bbox,
+        return_geometry=return_geometry,
+    )
+    return await fetch_json(FAA_AIS_SERVICES[service], params=params)
+
+
+def _features(data: dict[str, Any]) -> list[dict[str, Any]]:
+    return list(data.get("features") or [])
+
+
+def _attrs(feature: dict[str, Any]) -> dict[str, Any]:
+    return dict(feature.get("attributes") or feature.get("properties") or {})
+
+
+def _fmt_value(value: Any) -> str:
+    if value is None or value == "":
+        return "N/A"
+    return str(value)
+
+
+def _format_feature_lines(
+    *,
+    title: str,
+    data: dict[str, Any],
+    fields: list[tuple[str, str]],
+    limit: int,
+) -> str:
+    features = _features(data)[: _limit(limit, maximum=100)]
+    if not features:
+        return f"No {title.lower()} found.\n\n{PUBLIC_AVIATION_DISCLAIMER}"
+
+    lines = [f"**{title}** (showing {len(features)})\n"]
+    for feature in features:
+        attrs = _attrs(feature)
+        item: list[str] = []
+        primary = next((_fmt_value(attrs.get(name)) for name, _ in fields), "FAA record")
+        item.append(f"**{primary}**")
+        for field, label in fields:
+            item.append(f"- {label}: {_fmt_value(attrs.get(field))}")
+        geometry = feature.get("geometry")
+        if isinstance(geometry, dict):
+            if "x" in geometry and "y" in geometry:
+                item.append(f"- Geometry: {geometry['y']}, {geometry['x']}")
+            elif "rings" in geometry:
+                item.append("- Geometry: polygon")
+            elif "paths" in geometry:
+                item.append("- Geometry: line")
+        lines.append("\n".join(item))
+
+    lines.append(PUBLIC_AVIATION_DISCLAIMER)
+    return "\n\n---\n\n".join(lines)
+
+
+def _bbox_around(latitude: float, longitude: float, radius_nm: float) -> tuple[float, float, float, float]:
+    radius_nm = max(1.0, min(radius_nm, 250.0))
+    lat_delta = radius_nm / 60.0
+    lon_scale = max(math.cos(math.radians(latitude)), 0.1)
+    lon_delta = radius_nm / (60.0 * lon_scale)
+    return (
+        longitude - lon_delta,
+        latitude - lat_delta,
+        longitude + lon_delta,
+        latitude + lat_delta,
+    )
+
+
+@mcp.tool()
+async def search_faa_airports(query: str = "", state: str = "", limit: int = 10) -> str:
+    """Search FAA AIS public airport geodata by identifier, name, city, or state.
+
+    Args:
+        query: Airport identifier, ICAO ID, name, or served city.
+        state: Optional two-letter state code.
+        limit: Maximum records to return (default 10, max 50).
+
+    Returns:
+        Matching FAA AIS airport records with location and source caveat.
+    """
+    clauses = []
+    if query.strip():
+        q = query.strip()
+        exact_clauses = [f"({_airport_identifier_where(q)})"]
+        if state.strip():
+            exact_clauses.append(_equals("STATE", state.strip()))
+        exact_data = await _query_arcgis(
+            "airports",
+            where=" AND ".join(exact_clauses),
+            out_fields=[
+                "IDENT",
+                "ICAO_ID",
+                "NAME",
+                "SERVCITY",
+                "STATE",
+                "TYPE_CODE",
+                "OPERSTATUS",
+                "LATITUDE",
+                "LONGITUDE",
+                "ELEVATION",
+            ],
+            limit=limit,
+        )
+        if _features(exact_data):
+            return _format_feature_lines(
+                title="FAA AIS Airports",
+                data=exact_data,
+                fields=[
+                    ("IDENT", "Identifier"),
+                    ("ICAO_ID", "ICAO"),
+                    ("NAME", "Name"),
+                    ("SERVCITY", "Served city"),
+                    ("STATE", "State"),
+                    ("TYPE_CODE", "Type"),
+                    ("OPERSTATUS", "Status"),
+                    ("LATITUDE", "Latitude"),
+                    ("LONGITUDE", "Longitude"),
+                    ("ELEVATION", "Elevation"),
+                ],
+                limit=limit,
+            )
+        clauses.append(
+            "("
+            + " OR ".join(
+                [
+                    _contains("IDENT", q),
+                    _contains("ICAO_ID", q),
+                    _contains("NAME", q),
+                    _contains("SERVCITY", q),
+                ]
+            )
+            + ")"
+        )
+    if state.strip():
+        clauses.append(_equals("STATE", state.strip()))
+    where = " AND ".join(clauses) if clauses else "1=1"
+    data = await _query_arcgis(
+        "airports",
+        where=where,
+        out_fields=[
+            "IDENT",
+            "ICAO_ID",
+            "NAME",
+            "SERVCITY",
+            "STATE",
+            "TYPE_CODE",
+            "OPERSTATUS",
+            "LATITUDE",
+            "LONGITUDE",
+            "ELEVATION",
+        ],
+        limit=limit,
+    )
+    return _format_feature_lines(
+        title="FAA AIS Airports",
+        data=data,
+        fields=[
+            ("IDENT", "Identifier"),
+            ("ICAO_ID", "ICAO"),
+            ("NAME", "Name"),
+            ("SERVCITY", "Served city"),
+            ("STATE", "State"),
+            ("TYPE_CODE", "Type"),
+            ("OPERSTATUS", "Status"),
+            ("LATITUDE", "Latitude"),
+            ("LONGITUDE", "Longitude"),
+            ("ELEVATION", "Elevation"),
+        ],
+        limit=limit,
+    )
+
+
+@mcp.tool()
+async def get_faa_airport(identifier: str) -> str:
+    """Get one FAA AIS airport record by FAA identifier or ICAO ID."""
+    ident = identifier.strip().upper()
+    if not ident:
+        return "Error: identifier is required."
+    where = _airport_identifier_where(ident)
+    data = await _query_arcgis(
+        "airports",
+        where=where,
+        out_fields=["*"],
+        limit=1,
+    )
+    return _format_feature_lines(
+        title="FAA AIS Airport",
+        data=data,
+        fields=[
+            ("IDENT", "Identifier"),
+            ("ICAO_ID", "ICAO"),
+            ("NAME", "Name"),
+            ("SERVCITY", "Served city"),
+            ("STATE", "State"),
+            ("COUNTRY", "Country"),
+            ("TYPE_CODE", "Type"),
+            ("OPERSTATUS", "Status"),
+            ("PRIVATEUSE", "Private use"),
+            ("LATITUDE", "Latitude"),
+            ("LONGITUDE", "Longitude"),
+            ("ELEVATION", "Elevation"),
+        ],
+        limit=1,
+    )
+
+
+@mcp.tool()
+async def get_faa_runways(airport_id: str, limit: int = 20) -> str:
+    """Get FAA AIS runway records for an airport identifier."""
+    ident = airport_id.strip().upper()
+    if not ident:
+        return "Error: airport_id is required."
+    airport_data = await _query_arcgis(
+        "airports",
+        where=_airport_identifier_where(ident),
+        out_fields=["GLOBAL_ID", "IDENT", "ICAO_ID", "NAME"],
+        limit=1,
+        return_geometry=False,
+    )
+    airport_features = _features(airport_data)
+    if not airport_features:
+        return f"No FAA AIS airport found for {ident}.\n\n{PUBLIC_AVIATION_DISCLAIMER}"
+    airport_guid = _attrs(airport_features[0]).get("GLOBAL_ID")
+    if not airport_guid:
+        return f"FAA AIS airport {ident} did not include a runway lookup identifier."
+    where = _equals_raw("AIRPORT_ID", str(airport_guid))
+    data = await _query_arcgis(
+        "runways",
+        where=where,
+        out_fields=["AIRPORT_ID", "DESIGNATOR", "LENGTH", "WIDTH", "DIM_UOM", "COMP_CODE"],
+        limit=limit,
+    )
+    return _format_feature_lines(
+        title=f"FAA AIS Runways for {ident}",
+        data=data,
+        fields=[
+            ("AIRPORT_ID", "Airport"),
+            ("DESIGNATOR", "Runway"),
+            ("LENGTH", "Length"),
+            ("WIDTH", "Width"),
+            ("DIM_UOM", "Units"),
+            ("COMP_CODE", "Composition"),
+        ],
+        limit=limit,
+    )
+
+
+@mcp.tool()
+async def get_faa_airspace_near(
+    latitude: float,
+    longitude: float,
+    radius_nm: float = 25,
+    limit: int = 20,
+) -> str:
+    """Get FAA class and special-use airspace records near a coordinate."""
+    bbox = _bbox_around(latitude, longitude, radius_nm)
+    class_data = await _query_arcgis(
+        "class_airspace",
+        bbox=bbox,
+        out_fields=[
+            "IDENT",
+            "ICAO_ID",
+            "NAME",
+            "CLASS",
+            "TYPE_CODE",
+            "LOWER_DESC",
+            "UPPER_DESC",
+            "CITY",
+            "STATE",
+        ],
+        limit=limit,
+    )
+    sua_data = await _query_arcgis(
+        "special_use_airspace",
+        bbox=bbox,
+        out_fields=["IDENT", "NAME", "TYPE_CODE", "LOWER_DESC", "UPPER_DESC", "STATE"],
+        limit=limit,
+    )
+    class_section = _format_feature_lines(
+        title="FAA AIS Class Airspace",
+        data=class_data,
+        fields=[
+            ("IDENT", "Identifier"),
+            ("ICAO_ID", "ICAO"),
+            ("NAME", "Name"),
+            ("CLASS", "Class"),
+            ("TYPE_CODE", "Type"),
+            ("LOWER_DESC", "Lower"),
+            ("UPPER_DESC", "Upper"),
+            ("CITY", "City"),
+            ("STATE", "State"),
+        ],
+        limit=limit,
+    )
+    sua_section = _format_feature_lines(
+        title="FAA AIS Special Use Airspace",
+        data=sua_data,
+        fields=[
+            ("IDENT", "Identifier"),
+            ("NAME", "Name"),
+            ("TYPE_CODE", "Type"),
+            ("LOWER_DESC", "Lower"),
+            ("UPPER_DESC", "Upper"),
+            ("STATE", "State"),
+        ],
+        limit=limit,
+    )
+    return f"{class_section}\n\n===\n\n{sua_section}"
+
+
+@mcp.tool()
+async def get_faa_uas_facility_map(
+    latitude: float,
+    longitude: float,
+    radius_nm: float = 10,
+    limit: int = 20,
+) -> str:
+    """Get FAA UAS Facility Map records near a coordinate."""
+    data = await _query_arcgis(
+        "uas_facility_map",
+        bbox=_bbox_around(latitude, longitude, radius_nm),
+        out_fields=["*"],
+        limit=limit,
+    )
+    return _format_feature_lines(
+        title="FAA UAS Facility Map Data",
+        data=data,
+        fields=[
+            ("FACILITY", "Facility"),
+            ("CEILING", "Ceiling"),
+            ("APT1_FAAID", "Airport"),
+            ("GLOBAL_ID", "Global ID"),
+        ],
+        limit=limit,
+    )
+
+
+@mcp.tool()
+async def query_faa_ais(
+    service: str,
+    where: str = "1=1",
+    limit: int = 10,
+    bbox: list[float] | None = None,
+) -> dict[str, Any]:
+    """Make a raw bounded query to a public FAA AIS ArcGIS FeatureServer layer.
+
+    Args:
+        service: One of airports, runways, class_airspace, special_use_airspace,
+                 navaids, designated_points, obstacles, uas_facility_map.
+        where: ArcGIS SQL where clause.
+        limit: Maximum records to return (default 10, max 100).
+        bbox: Optional bounding box [xmin, ymin, xmax, ymax] in EPSG:4326.
+
+    Returns:
+        Raw FAA AIS ArcGIS JSON response.
+    """
+    bbox_tuple = (
+        (float(bbox[0]), float(bbox[1]), float(bbox[2]), float(bbox[3]))
+        if bbox and len(bbox) == 4
+        else None
+    )
+    return await _query_arcgis(
+        service,
+        where=where,
+        limit=limit,
+        bbox=bbox_tuple,
+    )
+
+
+def tfr_detail_url(notam_id: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9]+", "_", notam_id.strip()).strip("_")
+    return f"{FAA_TFR_BASE}/download/detail_{normalized}.xml"
+
+
+def parse_tfr_detail_xml(xml_text: str) -> dict[str, str]:
+    """Extract leaf XML tags from a TFR detail document."""
+    root = ElementTree.fromstring(xml_text)
+    result: dict[str, str] = {}
+    for elem in root.iter():
+        if list(elem):
+            continue
+        text = (elem.text or "").strip()
+        if not text:
+            continue
+        tag = elem.tag.split("}", 1)[-1]
+        if tag not in result:
+            result[tag] = text
+        if len(result) >= 80:
+            break
+    return result
+
+
+def _filter_tfr_records(
+    records: list[dict[str, Any]],
+    *,
+    state: str = "",
+    tfr_type: str = "",
+    facility: str = "",
+) -> list[dict[str, Any]]:
+    filtered = []
+    for record in records:
+        if state and str(record.get("state", "")).upper() != state.upper():
+            continue
+        if tfr_type and str(record.get("type", "")).upper() != tfr_type.upper():
+            continue
+        if facility and str(record.get("facility", "")).upper() != facility.upper():
+            continue
+        filtered.append(record)
+    return filtered
+
+
+def format_tfr_list(
+    records: list[dict[str, Any]],
+    *,
+    state: str = "",
+    tfr_type: str = "",
+    facility: str = "",
+    limit: int = 20,
+) -> str:
+    filtered = _filter_tfr_records(
+        records,
+        state=state,
+        tfr_type=tfr_type,
+        facility=facility,
+    )[: _limit(limit, maximum=100)]
+    if not filtered:
+        return f"No active FAA TFRs found for the requested filters.\n\n{PUBLIC_AVIATION_DISCLAIMER}"
+    lines = [f"**FAA Active Temporary Flight Restrictions** (showing {len(filtered)})\n"]
+    for record in filtered:
+        notam_id = _fmt_value(record.get("notam_id") or record.get("NOTAM_KEY"))
+        lines.append(
+            f"**{notam_id}**\n"
+            f"- Facility: {_fmt_value(record.get('facility'))}\n"
+            f"- State: {_fmt_value(record.get('state'))}\n"
+            f"- Type: {_fmt_value(record.get('type'))}\n"
+            f"- Description: {_fmt_value(record.get('description'))}\n"
+            f"- Modified: {_fmt_value(record.get('mod_date') or record.get('LAST_MODIFICATION_DATETIME'))}\n"
+            f"- Detail XML: {tfr_detail_url(notam_id)}"
+        )
+    lines.append(PUBLIC_AVIATION_DISCLAIMER)
+    return "\n\n---\n\n".join(lines)
+
+
+def _format_tfr_summary(records: list[dict[str, Any]]) -> str:
+    if not records:
+        return "No FAA TFR summary records returned."
+    lines = ["**FAA TFR Summary**\n"]
+    for record in records:
+        lines.append(
+            f"- {_fmt_value(record.get('center_id') or record.get('icao_name'))}: "
+            f"{_fmt_value(record.get('total_count'))} active, "
+            f"{_fmt_value(record.get('last_24_hours'))} in last 24h"
+        )
+    lines.append(PUBLIC_AVIATION_DISCLAIMER)
+    return "\n".join(lines)
+
+
+@mcp.tool()
+async def get_faa_tfrs(
+    state: str = "",
+    tfr_type: str = "",
+    facility: str = "",
+    limit: int = 20,
+) -> str:
+    """Get active FAA Temporary Flight Restrictions from the public TFR API."""
+    records = await fetch_json(f"{FAA_TFR_API_BASE}/getTfrList")
+    if not isinstance(records, list):
+        return "Unexpected FAA TFR API response."
+    return format_tfr_list(
+        records,
+        state=state,
+        tfr_type=tfr_type,
+        facility=facility,
+        limit=limit,
+    )
+
+
+@mcp.tool()
+async def get_faa_tfr_summary() -> str:
+    """Get FAA TFR counts by center/facility from the public TFR API."""
+    records = await fetch_json(f"{FAA_TFR_API_BASE}/getSummary")
+    if not isinstance(records, list):
+        return "Unexpected FAA TFR summary response."
+    return _format_tfr_summary(records)
+
+
+@mcp.tool()
+async def get_faa_tfr_shapes(state: str = "", limit: int = 25) -> dict[str, Any]:
+    """Get active FAA TFR shapes from the public GeoServer WFS endpoint."""
+    params = {
+        "service": "WFS",
+        "version": "1.1.0",
+        "request": "GetFeature",
+        "typeName": "TFR:V_TFR_LOC",
+        "maxFeatures": _limit(limit, maximum=300),
+        "outputFormat": "application/json",
+        "srsname": "EPSG:4326",
+    }
+    data = await fetch_json(FAA_TFR_WFS_URL, params=params)
+    if state:
+        features = [
+            feature
+            for feature in data.get("features", [])
+            if str(feature.get("properties", {}).get("STATE", "")).upper()
+            == state.upper()
+        ]
+        data = dict(data)
+        data["features"] = features[: _limit(limit, maximum=300)]
+    data["source_caveat"] = PUBLIC_AVIATION_DISCLAIMER
+    return data
+
+
+@mcp.tool()
+async def get_faa_tfr_detail(notam_id: str) -> dict[str, str]:
+    """Get parsed FAA TFR detail XML for a NOTAM ID such as '6/2842'."""
+    xml_text = await fetch_text(tfr_detail_url(notam_id))
+    parsed = parse_tfr_detail_xml(xml_text)
+    parsed["source_url"] = tfr_detail_url(notam_id)
+    parsed["source_caveat"] = PUBLIC_AVIATION_DISCLAIMER
+    return parsed
+
+
+def _event_parts(event: dict[str, Any]) -> list[str]:
+    parts: list[str] = []
+    ground_stop = event.get("groundStop")
+    if ground_stop:
+        parts.append(
+            "Ground Stop: "
+            + _fmt_value(ground_stop.get("reason") or ground_stop.get("impactingCondition"))
+        )
+    ground_delay = event.get("groundDelay")
+    if ground_delay:
+        parts.append(
+            "Ground Delay: "
+            f"avg {_fmt_value(ground_delay.get('avgDelay'))} min, "
+            f"max {_fmt_value(ground_delay.get('maxDelay'))} min"
+            f" ({_fmt_value(ground_delay.get('impactingCondition'))})"
+        )
+    closure = event.get("airportClosure")
+    if closure:
+        parts.append("Airport Closure: " + _fmt_value(closure.get("simpleText") or closure.get("text")))
+    free_form = event.get("freeForm")
+    if free_form:
+        parts.append("Notice: " + _fmt_value(free_form.get("simpleText") or free_form.get("text")))
+    arrival_delay = event.get("arrivalDelay")
+    if arrival_delay:
+        parts.append("Arrival Delay: " + _fmt_value(arrival_delay.get("delayReason") or arrival_delay))
+    departure_delay = event.get("departureDelay")
+    if departure_delay:
+        parts.append("Departure Delay: " + _fmt_value(departure_delay.get("delayReason") or departure_delay))
+    deicing = event.get("deicing")
+    if deicing:
+        parts.append("Deicing: " + _fmt_value(deicing.get("status") or deicing))
+    airport_config = event.get("airportConfig")
+    if airport_config:
+        parts.append(
+            "Runway config: "
+            f"arrivals {_fmt_value(airport_config.get('arrivalRunwayConfig'))}, "
+            f"departures {_fmt_value(airport_config.get('departureRunwayConfig'))}"
+        )
+    return parts
+
+
+def format_nas_airport_events(
+    events: list[dict[str, Any]],
+    *,
+    airport: str = "",
+    event_type: str = "",
+    limit: int = 20,
+) -> str:
+    filtered: list[dict[str, Any]] = []
+    for event in events:
+        if airport and str(event.get("airportId", "")).upper() != airport.upper():
+            continue
+        if event_type and not event.get(event_type):
+            continue
+        filtered.append(event)
+
+    filtered = filtered[: _limit(limit, maximum=100)]
+    if not filtered:
+        return f"No FAA NAS Status airport events found.\n\n{PUBLIC_AVIATION_DISCLAIMER}"
+
+    lines = [f"**FAA NAS Status Airport Events** (showing {len(filtered)})\n"]
+    for event in filtered:
+        airport_id = _fmt_value(event.get("airportId"))
+        name = _fmt_value(event.get("airportLongName"))
+        parts = _event_parts(event)
+        lines.append(
+            f"**{airport_id} - {name}**\n"
+            + "\n".join(f"- {part}" for part in parts)
+        )
+    lines.append(PUBLIC_AVIATION_DISCLAIMER)
+    return "\n\n---\n\n".join(lines)
+
+
+async def _nas_airport_events() -> list[dict[str, Any]]:
+    data = await fetch_json(f"{FAA_NAS_API_BASE}/airport-events")
+    return data if isinstance(data, list) else []
+
+
+@mcp.tool()
+async def get_faa_nas_airport_events(airport: str = "", limit: int = 20) -> str:
+    """Get current FAA NAS Status airport events, optionally filtered by airport."""
+    return format_nas_airport_events(await _nas_airport_events(), airport=airport, limit=limit)
+
+
+@mcp.tool()
+async def get_faa_ground_stops(airport: str = "", limit: int = 20) -> str:
+    """Get current FAA NAS Status airport ground stop events."""
+    return format_nas_airport_events(
+        await _nas_airport_events(),
+        airport=airport,
+        event_type="groundStop",
+        limit=limit,
+    )
+
+
+@mcp.tool()
+async def get_faa_ground_delays(airport: str = "", limit: int = 20) -> str:
+    """Get current FAA NAS Status airport ground delay events."""
+    return format_nas_airport_events(
+        await _nas_airport_events(),
+        airport=airport,
+        event_type="groundDelay",
+        limit=limit,
+    )
+
+
+@mcp.tool()
+async def get_faa_airport_closures(airport: str = "", limit: int = 20) -> str:
+    """Get current FAA NAS Status airport closure events."""
+    return format_nas_airport_events(
+        await _nas_airport_events(),
+        airport=airport,
+        event_type="airportClosure",
+        limit=limit,
+    )
+
+
+@mcp.tool()
+async def get_faa_operations_plan() -> dict[str, Any]:
+    """Get the current FAA NAS Status operations plan JSON."""
+    data = await fetch_json(f"{FAA_NAS_API_BASE}/operations-plan")
+    if isinstance(data, dict):
+        data = dict(data)
+        data["source_caveat"] = PUBLIC_AVIATION_DISCLAIMER
+    return data
+
+
+@mcp.tool()
+async def get_faa_artcc_boundaries() -> dict[str, Any]:
+    """Get FAA NAS Status ARTCC boundary data."""
+    data = await fetch_json(f"{FAA_NAS_API_BASE}/artcc-boundaries")
+    return {"boundaries": data, "source_caveat": PUBLIC_AVIATION_DISCLAIMER}
+
+
+def _read_csv_from_zip(archive: zipfile.ZipFile, name: str) -> list[dict[str, str]]:
+    try:
+        raw = archive.read(name)
+    except KeyError:
+        return []
+    text = raw.decode("utf-8", errors="replace")
+    rows = csv.DictReader(io.StringIO(text))
+    return [{(k or "").strip(): (v or "").strip() for k, v in row.items()} for row in rows]
+
+
+def _norm_header(row: dict[str, str], key: str) -> str:
+    return row.get(key, row.get(key.upper(), row.get(key.lower(), ""))).strip()
+
+
+def normalize_n_number(value: str) -> str:
+    value = re.sub(r"[^A-Za-z0-9]", "", value).upper()
+    if not value:
+        return ""
+    return value if value.startswith("N") else f"N{value}"
+
+
+def parse_aircraft_registry_zip(zip_data: bytes) -> dict[str, Any]:
+    """Parse FAA registry ZIP bytes into normalized master/reference records."""
+    with zipfile.ZipFile(io.BytesIO(zip_data)) as archive:
+        master_rows = _read_csv_from_zip(archive, "MASTER.txt")
+        acft_rows = _read_csv_from_zip(archive, "ACFTREF.txt")
+
+    refs: dict[str, dict[str, str]] = {}
+    for row in acft_rows:
+        code = _norm_header(row, "CODE")
+        if code:
+            refs[code] = row
+
+    records: list[dict[str, str]] = []
+    by_n_number: dict[str, dict[str, str]] = {}
+    for row in master_rows:
+        n_number = normalize_n_number(_norm_header(row, "N-NUMBER"))
+        if not n_number:
+            continue
+        model_code = _norm_header(row, "MFR MDL CODE")
+        ref = refs.get(model_code, {})
+        record = {
+            "n_number": n_number,
+            "registrant_name": _norm_header(row, "NAME"),
+            "manufacturer": _norm_header(ref, "MFR"),
+            "model": _norm_header(ref, "MODEL"),
+            "model_code": model_code,
+            "serial_number": _norm_header(row, "SERIAL NUMBER"),
+            "state": _norm_header(row, "STATE"),
+            "status_code": _norm_header(row, "STATUS CODE"),
+        }
+        records.append(record)
+        by_n_number[n_number] = record
+
+    return {
+        "records": records,
+        "by_n_number": by_n_number,
+        "aircraft_reference": refs,
+        "source_caveat": REGISTRY_PRIVACY_CAVEAT,
+    }
+
+
+def lookup_aircraft_registration_record(
+    registry: dict[str, Any],
+    n_number: str,
+) -> dict[str, str] | None:
+    return registry.get("by_n_number", {}).get(normalize_n_number(n_number))
+
+
+def search_aircraft_registry_records(
+    registry: dict[str, Any],
+    *,
+    make: str = "",
+    model: str = "",
+    state: str = "",
+    status: str = "",
+    limit: int = 10,
+) -> list[dict[str, str]]:
+    limit = _limit(limit, maximum=25)
+    results: list[dict[str, str]] = []
+    for record in registry.get("records", []):
+        if make and make.upper() not in record.get("manufacturer", "").upper():
+            continue
+        if model and model.upper() not in record.get("model", "").upper():
+            continue
+        if state and state.upper() != record.get("state", "").upper():
+            continue
+        if status and status.upper() != record.get("status_code", "").upper():
+            continue
+        results.append(record)
+        if len(results) >= limit:
+            break
+    return results
+
+
+async def _aircraft_registry() -> dict[str, Any]:
+    zip_data = await _cached_bytes(FAA_REGISTRY_ZIP_URL, "ReleasableAircraft.zip", 24 * 60 * 60)
+    return parse_aircraft_registry_zip(zip_data)
+
+
+def _format_registry_record(record: dict[str, str]) -> str:
+    return (
+        f"**{record.get('n_number', 'N/A')}**\n"
+        f"- Manufacturer: {_fmt_value(record.get('manufacturer'))}\n"
+        f"- Model: {_fmt_value(record.get('model'))}\n"
+        f"- Serial number: {_fmt_value(record.get('serial_number'))}\n"
+        f"- Registrant: {_fmt_value(record.get('registrant_name'))}\n"
+        f"- State: {_fmt_value(record.get('state'))}\n"
+        f"- Status code: {_fmt_value(record.get('status_code'))}"
+    )
+
+
+@mcp.tool()
+async def lookup_faa_aircraft_registration(n_number: str) -> str:
+    """Look up one aircraft in the FAA public aircraft registry by N-number."""
+    registry = await _aircraft_registry()
+    record = lookup_aircraft_registration_record(registry, n_number)
+    if not record:
+        return f"No FAA aircraft registry record found for {normalize_n_number(n_number)}."
+    return f"{_format_registry_record(record)}\n\n{REGISTRY_PRIVACY_CAVEAT}"
+
+
+@mcp.tool()
+async def search_faa_aircraft_registry(
+    make: str = "",
+    model: str = "",
+    state: str = "",
+    status: str = "",
+    limit: int = 10,
+) -> str:
+    """Search bounded FAA public aircraft registry records."""
+    if not any([make.strip(), model.strip(), state.strip(), status.strip()]):
+        return "Error: provide at least one filter: make, model, state, or status."
+    registry = await _aircraft_registry()
+    records = search_aircraft_registry_records(
+        registry,
+        make=make,
+        model=model,
+        state=state,
+        status=status,
+        limit=limit,
+    )
+    if not records:
+        return "No FAA aircraft registry records found for the requested filters."
+    lines = [f"**FAA Aircraft Registry Search** (showing {len(records)})\n"]
+    lines.extend(_format_registry_record(record) for record in records)
+    lines.append(REGISTRY_PRIVACY_CAVEAT)
+    return "\n\n---\n\n".join(lines)
+
+
+def _cell_text(cell: ElementTree.Element, shared_strings: list[str]) -> str:
+    ns = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+    value = cell.find(f"{ns}v")
+    if value is None or value.text is None:
+        inline = cell.find(f"{ns}is/{ns}t")
+        return (inline.text or "").strip() if inline is not None else ""
+    text = value.text.strip()
+    if cell.attrib.get("t") == "s":
+        try:
+            return shared_strings[int(text)]
+        except (ValueError, IndexError):
+            return ""
+    return text
+
+
+def _column_index(cell_ref: str) -> int:
+    letters = re.sub(r"[^A-Z]", "", cell_ref.upper())
+    index = 0
+    for letter in letters:
+        index = index * 26 + (ord(letter) - ord("A") + 1)
+    return max(index - 1, 0)
+
+
+def read_xlsx_rows(xlsx_data: bytes) -> list[list[str]]:
+    """Read rows from the first worksheet in a simple XLSX workbook."""
+    ns = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+    with zipfile.ZipFile(io.BytesIO(xlsx_data)) as archive:
+        shared_strings: list[str] = []
+        if "xl/sharedStrings.xml" in archive.namelist():
+            shared_root = ElementTree.fromstring(archive.read("xl/sharedStrings.xml"))
+            for item in shared_root.findall(f"{ns}si"):
+                texts = [node.text or "" for node in item.iter(f"{ns}t")]
+                shared_strings.append("".join(texts))
+
+        sheet_names = sorted(
+            name
+            for name in archive.namelist()
+            if name.startswith("xl/worksheets/sheet") and name.endswith(".xml")
+        )
+        if not sheet_names:
+            return []
+        root = ElementTree.fromstring(archive.read(sheet_names[0]))
+
+    rows: list[list[str]] = []
+    for row in root.findall(f".//{ns}row"):
+        values: dict[int, str] = {}
+        max_index = -1
+        for cell in row.findall(f"{ns}c"):
+            idx = _column_index(cell.attrib.get("r", "A1"))
+            values[idx] = _cell_text(cell, shared_strings)
+            max_index = max(max_index, idx)
+        if max_index >= 0:
+            rows.append([values.get(i, "") for i in range(max_index + 1)])
+    return rows
+
+
+def _normalize_header(value: str) -> str:
+    value = value.strip().lower()
+    value = value.replace("(", "").replace(")", "")
+    value = re.sub(r"[^a-z0-9]+", "_", value)
+    return value.strip("_")
+
+
+def parse_aircraft_characteristics_rows(rows: list[list[str]]) -> list[dict[str, str]]:
+    if not rows:
+        return []
+    header_index = 0
+    for idx, row in enumerate(rows[:10]):
+        normalized = [_normalize_header(cell) for cell in row]
+        if any(item in normalized for item in ["icao_code", "icao", "icao_aircraft_type"]):
+            header_index = idx
+            break
+    headers = [_normalize_header(cell) for cell in rows[header_index]]
+    records: list[dict[str, str]] = []
+    for row in rows[header_index + 1 :]:
+        raw = {headers[i]: row[i].strip() for i in range(min(len(headers), len(row)))}
+        icao = raw.get("icao_code") or raw.get("icao") or raw.get("icao_aircraft_type")
+        if not icao:
+            continue
+        wingspan = (
+            raw.get("wingspan_ft")
+            or raw.get("wingspan_ft_with_winglets_sharklets")
+            or raw.get("wingspan_ft_without_winglets_sharklets")
+            or raw.get("wingspan", "")
+        )
+        record = {
+            "icao_code": icao.upper(),
+            "manufacturer": raw.get("manufacturer", raw.get("make", "")).upper(),
+            "model": raw.get("model") or raw.get("model_faa") or raw.get("aircraft_model", ""),
+            "wingspan_ft": wingspan,
+            "approach_category": raw.get(
+                "approach_category",
+                raw.get("aac", raw.get("aircraft_approach_category", "")),
+            ),
+        }
+        for key, value in raw.items():
+            record.setdefault(key, value)
+        records.append(record)
+    return records
+
+
+def find_aircraft_characteristics(
+    records: list[dict[str, str]],
+    query: str,
+) -> dict[str, str] | None:
+    q = query.strip().upper()
+    for record in records:
+        if record.get("icao_code", "").upper() == q:
+            return record
+    for record in records:
+        haystack = " ".join(
+            [record.get("manufacturer", ""), record.get("model", ""), record.get("icao_code", "")]
+        ).upper()
+        if q in haystack:
+            return record
+    return None
+
+
+async def _aircraft_characteristics_records() -> list[dict[str, str]]:
+    xlsx_data = await _cached_bytes(
+        FAA_AIRCRAFT_CHARACTERISTICS_URL,
+        "aircraft_characteristics.xlsx",
+        7 * 24 * 60 * 60,
+    )
+    return parse_aircraft_characteristics_rows(read_xlsx_rows(xlsx_data))
+
+
+@mcp.tool()
+async def get_faa_aircraft_type_characteristics(query: str) -> str:
+    """Look up FAA aircraft type characteristics by ICAO type, make, or model."""
+    records = await _aircraft_characteristics_records()
+    record = find_aircraft_characteristics(records, query)
+    if not record:
+        return f"No FAA aircraft characteristics record found for '{query}'."
+    return (
+        f"**{record.get('icao_code', query.upper())} - {record.get('manufacturer', '')} "
+        f"{record.get('model', '')}**\n"
+        f"- Wingspan: {_fmt_value(record.get('wingspan_ft'))} ft\n"
+        f"- Approach category: {_fmt_value(record.get('approach_category'))}\n"
+        f"- Source: FAA Aircraft Characteristics Database\n\n"
+        "Aircraft characteristics are planning/design data, not live operational data."
+    )
+
+
+@mcp.tool()
+async def search_faa_aircraft_type_characteristics(query: str, limit: int = 10) -> str:
+    """Search FAA aircraft type characteristics by ICAO type, make, or model."""
+    records = await _aircraft_characteristics_records()
+    q = query.upper().strip()
+    matches = [
+        record
+        for record in records
+        if q
+        in " ".join(
+            [record.get("icao_code", ""), record.get("manufacturer", ""), record.get("model", "")]
+        ).upper()
+    ][: _limit(limit, maximum=25)]
+    if not matches:
+        return f"No FAA aircraft characteristics records found for '{query}'."
+    lines = [f"**FAA Aircraft Characteristics Search** (showing {len(matches)})\n"]
+    for record in matches:
+        lines.append(
+            f"**{record.get('icao_code', 'N/A')}** - "
+            f"{record.get('manufacturer', '')} {record.get('model', '')}\n"
+            f"- Wingspan: {_fmt_value(record.get('wingspan_ft'))} ft\n"
+            f"- Approach category: {_fmt_value(record.get('approach_category'))}"
+        )
+    return "\n\n---\n\n".join(lines)
+
+
+def format_faa_catalog_results(data: dict[str, Any], *, query: str, rows: int) -> str:
+    result = data.get("result", {})
+    datasets = result.get("results", [])[: _limit(rows, maximum=50)]
+    total = result.get("count", 0)
+    if not datasets:
+        return f"No FAA catalog datasets found for '{query}'."
+    output = [f"**FAA Data Catalog Search: '{query}'**"]
+    output.append(f"Found {total} datasets (showing {len(datasets)})\n")
+    for dataset in datasets:
+        resources = dataset.get("resources", [])
+        lines = [
+            f"**{dataset.get('title', 'Untitled')}**",
+            f"Last updated: {_fmt_value(str(dataset.get('metadata_modified', ''))[:10])}",
+            f"Resources: {len(resources)}",
+            str(dataset.get("notes", "No description"))[:240],
+        ]
+        for resource in resources[:5]:
+            lines.append(
+                f"- [{_fmt_value(resource.get('format'))}] "
+                f"{_fmt_value(resource.get('name') or resource.get('description'))}: "
+                f"{_fmt_value(resource.get('url'))}"
+            )
+        output.append("\n".join(lines))
+    return "\n\n---\n\n".join(output)
+
+
+@mcp.tool()
+async def search_faa_catalog(query: str, rows: int = 10) -> str:
+    """Search the FAA Data Catalog CKAN API."""
+    rows = _limit(rows, maximum=50)
+    data = await fetch_json(
+        f"{FAA_CATALOG_BASE}/action/package_search",
+        params={"q": query, "rows": rows},
+    )
+    return format_faa_catalog_results(data, query=query, rows=rows)
+
+
+@mcp.tool()
+async def query_faa_catalog(action: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Make a raw query to the FAA Data Catalog CKAN API."""
+    return await fetch_json(f"{FAA_CATALOG_BASE}/action/{action}", params=params)

--- a/src/mcp_govt_api/tools/fda.py
+++ b/src/mcp_govt_api/tools/fda.py
@@ -166,7 +166,7 @@ async def get_fda_adverse_events(
         lines.append(f"  Drugs Involved: {drugs_str}")
         lines.append("")
 
-    lines.append(f"_Source: openFDA Drug Adverse Events (FAERS)_")
+    lines.append("_Source: openFDA Drug Adverse Events (FAERS)_")
 
     return "\n".join(lines)
 
@@ -245,6 +245,6 @@ async def get_fda_drug_labels(
         lines.append(f"  Dosage: {dosage}")
         lines.append("")
 
-    lines.append(f"_Source: openFDA Drug Labels (SPL)_")
+    lines.append("_Source: openFDA Drug Labels (SPL)_")
 
     return "\n".join(lines)

--- a/src/mcp_govt_api/tools/fred.py
+++ b/src/mcp_govt_api/tools/fred.py
@@ -2,7 +2,6 @@ from mcp_govt_api.server import mcp
 from mcp_govt_api.utils.config import config
 from mcp_govt_api.utils.http import fetch_json
 
-
 FRED_BASE = "https://api.stlouisfed.org/fred"
 
 

--- a/src/mcp_govt_api/tools/n2yo.py
+++ b/src/mcp_govt_api/tools/n2yo.py
@@ -8,7 +8,7 @@ Requires a free API key from https://www.n2yo.com/
 """
 
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from mcp_govt_api.server import mcp
@@ -186,7 +186,7 @@ async def get_satellite_position(
         time_str = "N/A"
         if timestamp:
             try:
-                dt = datetime.fromtimestamp(timestamp, tz=timezone.utc)
+                dt = datetime.fromtimestamp(timestamp, tz=UTC)
                 time_str = dt.strftime("%Y-%m-%d %H:%M:%S UTC")
             except (OSError, ValueError):
                 time_str = str(timestamp)

--- a/src/mcp_govt_api/tools/nces.py
+++ b/src/mcp_govt_api/tools/nces.py
@@ -1,7 +1,6 @@
 from mcp_govt_api.server import mcp
 from mcp_govt_api.utils.http import fetch_json
 
-
 NCES_BASE = "https://educationdata.urban.org/api/v1"
 
 

--- a/src/mcp_govt_api/tools/noaa_coops.py
+++ b/src/mcp_govt_api/tools/noaa_coops.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta
 from mcp_govt_api.server import mcp
 from mcp_govt_api.utils.http import fetch_json
 
-
 COOPS_DATA_BASE = "https://api.tidesandcurrents.noaa.gov/api/prod/datagetter"
 COOPS_STATIONS_BASE = "https://api.tidesandcurrents.noaa.gov/mdapi/prod/webapi/stations.json"
 

--- a/src/mcp_govt_api/tools/noaa_weather.py
+++ b/src/mcp_govt_api/tools/noaa_weather.py
@@ -1,7 +1,6 @@
 from mcp_govt_api.server import mcp
 from mcp_govt_api.utils.http import fetch_json
 
-
 NOAA_BASE = "https://api.weather.gov"
 
 # Common WFO codes for reference
@@ -132,7 +131,7 @@ async def get_active_weather_alerts(
             ]
 
         if not alerts:
-            filter_desc = f" matching filters" if event or severity else ""
+            filter_desc = " matching filters" if event or severity else ""
             return f"No active weather alerts for {state}{filter_desc}."
 
         # Sort by severity order
@@ -198,7 +197,7 @@ async def get_radar_stations(state: str = "") -> str:
         if not features:
             return f"No radar stations found for state '{state}'."
 
-        result = [f"NEXRAD Radar Stations" + (f" in {state}" if state else "") + f" ({len(features)} stations):\n"]
+        result = ["NEXRAD Radar Stations" + (f" in {state}" if state else "") + f" ({len(features)} stations):\n"]
         for feat in features:
             props = feat.get("properties", {})
             coords = feat.get("geometry", {}).get("coordinates", [None, None])

--- a/src/mcp_govt_api/tools/nps.py
+++ b/src/mcp_govt_api/tools/nps.py
@@ -2,7 +2,6 @@ from mcp_govt_api.server import mcp
 from mcp_govt_api.utils.config import config
 from mcp_govt_api.utils.http import fetch_json
 
-
 NPS_BASE = "https://developer.nps.gov/api/v1"
 
 

--- a/src/mcp_govt_api/tools/osha.py
+++ b/src/mcp_govt_api/tools/osha.py
@@ -78,7 +78,7 @@ async def search_osha_inspections(
             lines.append(f"  Total Penalty: ${nr_violations}")
         lines.append("")
 
-    lines.append(f"_Source: OSHA Enforcement Data (DOL)_")
+    lines.append("_Source: OSHA Enforcement Data (DOL)_")
     return "\n".join(lines)
 
 
@@ -150,7 +150,7 @@ async def get_osha_violations(
             lines.append(f"  Abatement Complete: {contest}")
         lines.append("")
 
-    lines.append(f"_Source: OSHA Enforcement Data (DOL)_")
+    lines.append("_Source: OSHA Enforcement Data (DOL)_")
     return "\n".join(lines)
 
 
@@ -214,5 +214,5 @@ async def search_osha_fatalities(
         lines.append(f"  Summary: {summary}")
         lines.append("")
 
-    lines.append(f"_Source: OSHA Fatality and Catastrophe Reports (DOL)_")
+    lines.append("_Source: OSHA Fatality and Catastrophe Reports (DOL)_")
     return "\n".join(lines)

--- a/src/mcp_govt_api/tools/sec.py
+++ b/src/mcp_govt_api/tools/sec.py
@@ -191,7 +191,7 @@ async def search_company(name: str = "", ticker: str = "") -> str:
                         f"- **{m['name']}** | Ticker: {m['ticker']} | CIK: {m['cik']}"
                     )
                 result.append(
-                    f"\nUse the CIK number with `get_company_filings` or `get_latest_submissions`."
+                    "\nUse the CIK number with `get_company_filings` or `get_latest_submissions`."
                 )
                 return "\n".join(result)
             else:

--- a/src/mcp_govt_api/tools/usda.py
+++ b/src/mcp_govt_api/tools/usda.py
@@ -1,7 +1,6 @@
 from mcp_govt_api.server import mcp
-from mcp_govt_api.utils.http import fetch_json
 from mcp_govt_api.utils.config import config
-
+from mcp_govt_api.utils.http import fetch_json
 
 FDC_BASE = "https://api.nal.usda.gov/fdc/v1"
 NASS_BASE = "https://quickstats.nass.usda.gov/api"
@@ -75,10 +74,14 @@ async def search_usda_foods(
             name = n.get("nutrientName", "")
             value = n.get("value")
             unit = n.get("unitName", "")
-            if name and value is not None:
-                if name in ("Energy", "Protein", "Total lipid (fat)",
-                            "Carbohydrate, by difference", "Fiber, total dietary"):
-                    nutrient_strs.append(f"{name}: {value} {unit}")
+            if name and value is not None and name in (
+                "Energy",
+                "Protein",
+                "Total lipid (fat)",
+                "Carbohydrate, by difference",
+                "Fiber, total dietary",
+            ):
+                nutrient_strs.append(f"{name}: {value} {unit}")
         if nutrient_strs:
             parts.append(" | ".join(nutrient_strs))
 

--- a/src/mcp_govt_api/tools/usfs.py
+++ b/src/mcp_govt_api/tools/usfs.py
@@ -1,3 +1,5 @@
+from datetime import UTC
+
 from mcp_govt_api.server import mcp
 from mcp_govt_api.utils.http import fetch_json
 
@@ -118,9 +120,9 @@ async def get_active_wildfires(
         if discovery:
             # Convert epoch milliseconds to readable date
             try:
-                from datetime import datetime, timezone
+                from datetime import datetime
 
-                dt = datetime.fromtimestamp(discovery / 1000, tz=timezone.utc)
+                dt = datetime.fromtimestamp(discovery / 1000, tz=UTC)
                 lines.append(f"  Discovered: {dt.strftime('%Y-%m-%d %H:%M UTC')}")
             except (ValueError, OSError):
                 pass
@@ -207,9 +209,9 @@ async def get_wildfire_perimeters(
             lines.append(f"  Containment: {containment}%")
         if create_date:
             try:
-                from datetime import datetime, timezone
+                from datetime import datetime
 
-                dt = datetime.fromtimestamp(create_date / 1000, tz=timezone.utc)
+                dt = datetime.fromtimestamp(create_date / 1000, tz=UTC)
                 lines.append(f"  Perimeter Date: {dt.strftime('%Y-%m-%d')}")
             except (ValueError, OSError):
                 pass
@@ -248,14 +250,10 @@ async def search_national_forests(
 
     where_parts = []
     if state:
-        state_clause = _state_where(state, "ADMINFORESTID")
         # National Forest boundaries use different field names; try FORESTNAME state matching
         # Use a LIKE on FORESTNAME which often includes state context
         st = state.strip().upper()
-        if len(st) == 2:
-            full_name = STATE_NAMES.get(st, st)
-        else:
-            full_name = state.strip()
+        full_name = STATE_NAMES.get(st, st) if len(st) == 2 else state.strip()
         where_parts.append(f"UPPER(FORESTNAME) LIKE '%{full_name.upper()}%' OR UPPER(GIS_ACRES) >= 0")
         # Actually, the boundary service stores state info differently.
         # Use a general approach - filter by name if state given

--- a/src/mcp_govt_api/utils/config.py
+++ b/src/mcp_govt_api/utils/config.py
@@ -106,6 +106,7 @@ class Config:
                 "  ✓ NOAA Space Weather (no key required)",
                 "  ✓ SEC EDGAR (no key required)",
                 "  ✓ CISA (no key required)",
+                "  ✓ FAA Public Aviation Data (no key required)",
             ]
         )
         if self.has_fred:

--- a/src/mcp_govt_api/utils/http.py
+++ b/src/mcp_govt_api/utils/http.py
@@ -1,14 +1,14 @@
-from typing import Any
-from contextlib import asynccontextmanager
-from collections.abc import AsyncIterator
 import asyncio
 import logging
 import random
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any, NoReturn
 
 import httpx
 
-from mcp_govt_api.utils.config import config
 from mcp_govt_api.utils.cache import response_cache
+from mcp_govt_api.utils.config import config
 from mcp_govt_api.utils.errors import (
     APIError,
     AuthenticationError,
@@ -50,9 +50,7 @@ def _is_retryable_error(exc: Exception) -> bool:
         return True
     if isinstance(exc, httpx.HTTPStatusError):
         return exc.response.status_code in RETRYABLE_STATUS_CODES
-    if isinstance(exc, (httpx.ConnectError, httpx.ReadError, httpx.WriteError)):
-        return True
-    return False
+    return isinstance(exc, (httpx.ConnectError, httpx.ReadError, httpx.WriteError))
 
 
 async def _retry_delay(attempt: int, base_delay: float = DEFAULT_BASE_DELAY) -> None:
@@ -65,7 +63,7 @@ async def _retry_delay(attempt: int, base_delay: float = DEFAULT_BASE_DELAY) -> 
     await asyncio.sleep(delay + jitter)
 
 
-def _raise_specific_error(last_exception: Exception | None, url: str) -> None:
+def _raise_specific_error(last_exception: Exception | None, url: str) -> NoReturn:
     """Convert the last caught exception into a specific error type and raise."""
     if isinstance(last_exception, httpx.TimeoutException):
         raise TimeoutError(
@@ -238,3 +236,23 @@ async def fetch_with_retry(
                 )
 
     _raise_specific_error(last_exception, url)
+
+
+async def fetch_text(
+    url: str,
+    params: dict[str, Any] | None = None,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> str:
+    """Fetch text content with retry-aware HTTP error handling."""
+    response = await fetch_with_retry(url, params=params, max_retries=max_retries)
+    return response.text
+
+
+async def fetch_bytes(
+    url: str,
+    params: dict[str, Any] | None = None,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> bytes:
+    """Fetch binary content with retry-aware HTTP error handling."""
+    response = await fetch_with_retry(url, params=params, max_retries=max_retries)
+    return response.content

--- a/src/mcp_govt_api/utils/logging.py
+++ b/src/mcp_govt_api/utils/logging.py
@@ -3,7 +3,7 @@
 import json
 import logging
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from mcp_govt_api.utils.config import config
 
@@ -14,7 +14,7 @@ class JSONFormatter(logging.Formatter):
     def format(self, record: logging.LogRecord) -> str:
         log_entry = {
             "timestamp": datetime.fromtimestamp(
-                record.created, tz=timezone.utc
+                record.created, tz=UTC
             ).isoformat(),
             "level": record.levelname,
             "module": record.module,

--- a/src/mcp_govt_api/utils/validation.py
+++ b/src/mcp_govt_api/utils/validation.py
@@ -81,10 +81,10 @@ def validate_date(date_str: str, fmt: str = "%Y-%m-%d") -> str:
     date_str = date_str.strip()
     try:
         datetime.strptime(date_str, fmt)
-    except ValueError:
+    except ValueError as exc:
         raise ValueError(
             f"Invalid date '{date_str}'. Expected format: {fmt}"
-        )
+        ) from exc
     return date_str
 
 
@@ -99,8 +99,8 @@ def validate_latitude(lat: float) -> float:
     """
     try:
         lat = float(lat)
-    except (TypeError, ValueError):
-        raise ValueError(f"Latitude must be a number, got {lat!r}.")
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Latitude must be a number, got {lat!r}.") from exc
     if lat < -90 or lat > 90:
         raise ValueError(
             f"Latitude must be between -90 and 90, got {lat}."
@@ -119,8 +119,8 @@ def validate_longitude(lon: float) -> float:
     """
     try:
         lon = float(lon)
-    except (TypeError, ValueError):
-        raise ValueError(f"Longitude must be a number, got {lon!r}.")
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Longitude must be a number, got {lon!r}.") from exc
     if lon < -180 or lon > 180:
         raise ValueError(
             f"Longitude must be between -180 and 180, got {lon}."
@@ -139,8 +139,8 @@ def validate_magnitude(value: float) -> float:
     """
     try:
         value = float(value)
-    except (TypeError, ValueError):
-        raise ValueError(f"Magnitude must be a number, got {value!r}.")
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Magnitude must be a number, got {value!r}.") from exc
     if value < 0 or value > 10:
         raise ValueError(
             f"Magnitude must be between 0 and 10, got {value}."

--- a/tests/test_census.py
+++ b/tests/test_census.py
@@ -48,14 +48,16 @@ class TestGetPopulation(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("County 20", result)
 
     async def test_invalid_state(self):
-        with self.assertRaises(ValueError):
-            await get_population(state="ZZ")
+        result = await get_population(state="ZZ")
+        self.assertIn("Error: [Census API]", result)
+        self.assertIn("ZZ", result)
 
     @patch("mcp_govt_api.tools.census.fetch_json", new_callable=AsyncMock)
     async def test_network_error(self, mock_fetch):
         mock_fetch.side_effect = Exception("Network error")
-        with self.assertRaises(Exception):
-            await get_population(state="CA")
+        result = await get_population(state="CA")
+        self.assertIn("Error: [Census API]", result)
+        self.assertIn("Network error", result)
 
 
 class TestGetDemographics(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_faa_tools.py
+++ b/tests/test_faa_tools.py
@@ -1,0 +1,288 @@
+import asyncio
+import io
+import zipfile
+
+from mcp_govt_api.tools import faa
+
+
+def _zip_bytes(files: dict[str, str | bytes]) -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w") as archive:
+        for name, content in files.items():
+            archive.writestr(name, content)
+    return buffer.getvalue()
+
+
+def _minimal_xlsx() -> bytes:
+    return _zip_bytes(
+        {
+            "[Content_Types].xml": """<?xml version="1.0" encoding="UTF-8"?>
+                <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+                  <Override PartName="/xl/worksheets/sheet1.xml"
+                    ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+                  <Override PartName="/xl/sharedStrings.xml"
+                    ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+                </Types>""",
+            "xl/sharedStrings.xml": """<?xml version="1.0" encoding="UTF-8"?>
+                <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                  <si><t>ICAO Code</t></si>
+                  <si><t>Manufacturer</t></si>
+                  <si><t>Model</t></si>
+                  <si><t>Wingspan (ft)</t></si>
+                  <si><t>Approach Category</t></si>
+                  <si><t>B738</t></si>
+                  <si><t>BOEING</t></si>
+                  <si><t>737-800</t></si>
+                  <si><t>117.5</t></si>
+                  <si><t>C</t></si>
+                </sst>""",
+            "xl/worksheets/sheet1.xml": """<?xml version="1.0" encoding="UTF-8"?>
+                <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+                  <sheetData>
+                    <row r="1">
+                      <c r="A1" t="s"><v>0</v></c>
+                      <c r="B1" t="s"><v>1</v></c>
+                      <c r="C1" t="s"><v>2</v></c>
+                      <c r="D1" t="s"><v>3</v></c>
+                      <c r="E1" t="s"><v>4</v></c>
+                    </row>
+                    <row r="2">
+                      <c r="A2" t="s"><v>5</v></c>
+                      <c r="B2" t="s"><v>6</v></c>
+                      <c r="C2" t="s"><v>7</v></c>
+                      <c r="D2" t="s"><v>8</v></c>
+                      <c r="E2" t="s"><v>9</v></c>
+                    </row>
+                  </sheetData>
+                </worksheet>""",
+        }
+    )
+
+
+def test_faa_source_metadata_includes_public_safety_caveat() -> None:
+    assert "FAA AIS" in faa.FAA_SOURCES
+    assert "informational" in faa.PUBLIC_AVIATION_DISCLAIMER.lower()
+    assert faa.FAA_SOURCES["FAA Aircraft Registry"]["auth"] == "none"
+
+
+def test_arcgis_query_params_include_bbox_limit_and_fields() -> None:
+    params = faa.build_arcgis_query_params(
+        where="STATE = 'CA'",
+        out_fields=["IDENT", "NAME"],
+        limit=5,
+        bbox=(-119.0, 33.0, -117.0, 35.0),
+    )
+
+    assert params["f"] == "json"
+    assert params["where"] == "STATE = 'CA'"
+    assert params["outFields"] == "IDENT,NAME"
+    assert params["resultRecordCount"] == 5
+    assert params["returnGeometry"] == "true"
+    assert params["geometryType"] == "esriGeometryEnvelope"
+    assert '"xmin": -119.0' in params["geometry"]
+
+
+def test_search_faa_airports_prefers_exact_identifier(monkeypatch) -> None:
+    calls = []
+
+    async def fake_query_arcgis(service, *, where="1=1", out_fields=None, limit=10, **kwargs):
+        calls.append((service, where, out_fields, limit, kwargs))
+        return {
+            "features": [
+                {
+                    "attributes": {
+                        "IDENT": "LAX",
+                        "ICAO_ID": "KLAX",
+                        "NAME": "Los Angeles Intl",
+                        "SERVCITY": "LOS ANGELES",
+                        "STATE": "CA",
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(faa, "_query_arcgis", fake_query_arcgis)
+
+    output = asyncio.run(faa.search_faa_airports(query="LAX", limit=1))
+
+    assert "Los Angeles Intl" in output
+    assert len(calls) == 1
+    assert "IDENT = 'LAX'" in calls[0][1]
+
+
+def test_get_faa_runways_resolves_airport_global_id(monkeypatch) -> None:
+    calls = []
+
+    async def fake_query_arcgis(service, *, where="1=1", out_fields=None, limit=10, **kwargs):
+        calls.append((service, where, out_fields, limit, kwargs))
+        if service == "airports":
+            return {
+                "features": [
+                    {"attributes": {"IDENT": "LAX", "ICAO_ID": "KLAX", "GLOBAL_ID": "airport-guid"}}
+                ]
+            }
+        return {
+            "features": [
+                {
+                    "attributes": {
+                        "AIRPORT_ID": "airport-guid",
+                        "DESIGNATOR": "06L/24R",
+                        "LENGTH": 8925,
+                        "WIDTH": 150,
+                        "DIM_UOM": "FT",
+                        "COMP_CODE": "CONC",
+                    }
+                }
+            ]
+        }
+
+    monkeypatch.setattr(faa, "_query_arcgis", fake_query_arcgis)
+
+    output = asyncio.run(faa.get_faa_runways("LAX", limit=2))
+
+    assert "06L/24R" in output
+    assert calls[0][0] == "airports"
+    assert calls[1][0] == "runways"
+    assert calls[1][1] == "AIRPORT_ID = 'airport-guid'"
+
+
+def test_tfr_helpers_filter_state_and_parse_detail_xml() -> None:
+    records = [
+        {
+            "notam_id": "6/2842",
+            "facility": "ZDC",
+            "state": "VA",
+            "type": "VIP",
+            "description": "MIDDLEBURG, VA",
+            "mod_date": "07/04/2026 02:31:00",
+        },
+        {
+            "notam_id": "6/2828",
+            "facility": "ZBW",
+            "state": "MA",
+            "type": "SECURITY",
+            "description": "Boston, MA",
+        },
+    ]
+
+    output = faa.format_tfr_list(records, state="va", limit=5)
+
+    assert "6/2842" in output
+    assert "MIDDLEBURG" in output
+    assert "6/2828" not in output
+    assert "verify official FAA" in output
+    assert faa.tfr_detail_url("6/2842").endswith("/download/detail_6_2842.xml")
+
+    parsed = faa.parse_tfr_detail_xml(
+        "<XNOTAM><notam_id>6/2842</notam_id><title>VIP movement</title></XNOTAM>"
+    )
+    assert parsed == {"notam_id": "6/2842", "title": "VIP movement"}
+
+
+def test_nas_airport_event_formatter_filters_and_summarizes_events() -> None:
+    events = [
+        {
+            "airportId": "DCA",
+            "airportLongName": "Ronald Reagan Washington National",
+            "groundDelay": {
+                "avgDelay": 35,
+                "maxDelay": 55,
+                "impactingCondition": "air show",
+            },
+            "airportClosure": {"simpleText": "!DCA AD AP CLSD"},
+            "arrivalDelay": None,
+            "departureDelay": None,
+        },
+        {"airportId": "EWR", "freeForm": {"simpleText": "EWR notice"}},
+    ]
+
+    output = faa.format_nas_airport_events(events, airport="dca")
+
+    assert "DCA" in output
+    assert "Ground Delay" in output
+    assert "air show" in output
+    assert "Airport Closure" in output
+    assert "EWR" not in output
+
+
+def test_registry_zip_parser_normalizes_n_numbers_and_joins_reference() -> None:
+    zip_data = _zip_bytes(
+        {
+            "MASTER.txt": (
+                "N-NUMBER,NAME,MFR MDL CODE,SERIAL NUMBER,STATE,STATUS CODE\n"
+                "23FX,DOE AVIATION LLC,0563361,1234,TX,V\n"
+            ),
+            "ACFTREF.txt": "CODE,MFR,MODEL,TYPE-ACFT,TYPE-ENG\n0563361,CIRRUS DESIGN CORP,SR22,4,1\n",
+        }
+    )
+
+    registry = faa.parse_aircraft_registry_zip(zip_data)
+    record = faa.lookup_aircraft_registration_record(registry, "N23FX")
+    matches = faa.search_aircraft_registry_records(registry, make="cirrus", limit=5)
+
+    assert record is not None
+    assert record["n_number"] == "N23FX"
+    assert record["manufacturer"] == "CIRRUS DESIGN CORP"
+    assert record["model"] == "SR22"
+    assert matches == [record]
+
+
+def test_aircraft_characteristics_xlsx_parser_normalizes_rows() -> None:
+    rows = faa.read_xlsx_rows(_minimal_xlsx())
+    records = faa.parse_aircraft_characteristics_rows(rows)
+
+    assert records == [
+        {
+            "icao_code": "B738",
+            "manufacturer": "BOEING",
+            "model": "737-800",
+            "wingspan_ft": "117.5",
+            "approach_category": "C",
+        }
+    ]
+    assert faa.find_aircraft_characteristics(records, "b738") == records[0]
+
+
+def test_aircraft_characteristics_parser_maps_live_faa_headers() -> None:
+    rows = [
+        [
+            "ICAO_Code",
+            "FAA_Designator",
+            "Manufacturer",
+            "Model_FAA",
+            "AAC",
+            "Wingspan_ft_without_winglets_sharklets",
+            "Wingspan_ft_with_winglets_sharklets",
+        ],
+        ["B738", "B738", "BOEING", "Boeing 737-800", "D", "112.6", "117.4"],
+    ]
+
+    records = faa.parse_aircraft_characteristics_rows(rows)
+
+    assert records[0]["icao_code"] == "B738"
+    assert records[0]["model"] == "Boeing 737-800"
+    assert records[0]["wingspan_ft"] == "117.4"
+    assert records[0]["approach_category"] == "D"
+
+
+def test_faa_catalog_formatter_reports_count_and_resources() -> None:
+    data = {
+        "result": {
+            "count": 1,
+            "results": [
+                {
+                    "title": "FAA Chart Supplements",
+                    "notes": "Airport and facility directory data.",
+                    "metadata_modified": "2026-07-01T00:00:00",
+                    "resources": [{"format": "PDF", "url": "https://example.test/chart.pdf"}],
+                }
+            ],
+        }
+    }
+
+    output = faa.format_faa_catalog_results(data, query="chart", rows=10)
+
+    assert "FAA Chart Supplements" in output
+    assert "Found 1 datasets" in output
+    assert "PDF" in output
+    assert "https://example.test/chart.pdf" in output

--- a/tests/test_weather.py
+++ b/tests/test_weather.py
@@ -71,8 +71,9 @@ class TestGetWeatherForecast(unittest.IsolatedAsyncioTestCase):
         )
         mock_fetch.side_effect = Exception("Connection refused")
 
-        with self.assertRaises(Exception):
-            await get_weather_forecast(latitude=38.0, longitude=-77.0)
+        result = await get_weather_forecast(latitude=38.0, longitude=-77.0)
+        self.assertIn("Error: [NOAA Weather]", result)
+        self.assertIn("Connection refused", result)
 
 
 class TestGetWeatherAlerts(unittest.IsolatedAsyncioTestCase):


### PR DESCRIPTION
## Summary
- Add 22 public FAA aviation MCP tools across AIS geodata, TFRs, NAS Status, Aircraft Registry, Aircraft Characteristics, and FAA Data Catalog search.
- Add cache-backed handling for large FAA registry ZIP/workbook sources plus explicit FAA operational safety and registry privacy caveats.
- Document FAA source coverage and intentionally defer Wildlife Strike wrapping until a production/public-use endpoint is confirmed.
- Bring current `src/` lint/typecheck/test expectations green on the rebased branch.

## Validation
- `uv run --extra dev ruff check src/` -> passed
- `uv run --extra dev mypy src/` -> passed across 61 source files
- `uv run --extra dev pytest --cov=mcp_govt_api --cov-report=xml` -> 788 passed
- `uv run --extra dev python -m compileall src` -> passed
- `uv run --extra dev python -c "import mcp_govt_api; import mcp_govt_api.server"` -> passed
- `uv build` -> passed
- Live FAA smoke checks covered AIS airport/runway, TFR summary/detail/shapes, NAS events/operations/boundaries, aircraft characteristics, FAA catalog search, and registry range GET availability.

Closes #144
Closes #145
Closes #146
Closes #147
Closes #148
Closes #149
Closes #150
Closes #151
Closes #152
Closes #153